### PR TITLE
BottomSheet の scrim をステータスバーに被せた

### DIFF
--- a/core/designsystem/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/FullScrimModalBottomSheet.kt
+++ b/core/designsystem/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/FullScrimModalBottomSheet.kt
@@ -1,0 +1,60 @@
+package app.kaito_dogi.mybrary.core.designsystem.component
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.contentColorFor
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FullScrimModalBottomSheet(
+  onDismissRequest: () -> Unit,
+  modifier: Modifier = Modifier,
+  sheetState: SheetState = rememberModalBottomSheetState(),
+  shape: Shape = BottomSheetDefaults.ExpandedShape,
+  containerColor: Color = BottomSheetDefaults.ContainerColor,
+  contentColor: Color = contentColorFor(containerColor),
+  tonalElevation: Dp = BottomSheetDefaults.Elevation,
+  scrimColor: Color = BottomSheetDefaults.ScrimColor,
+  dragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
+  content: @Composable ColumnScope.() -> Unit,
+) {
+  val density = LocalDensity.current
+  val layoutDirection = LocalLayoutDirection.current
+
+  val left = BottomSheetDefaults.windowInsets.getLeft(density, layoutDirection)
+  val right = BottomSheetDefaults.windowInsets.getRight(density, layoutDirection)
+  val bottom = BottomSheetDefaults.windowInsets.getBottom(density)
+
+  // status bar まで scrim を表示するため、WindowInsets の top を0にする
+  val customWindowInsets = WindowInsets(
+    left = left,
+    top = 0,
+    right = right,
+    bottom = bottom,
+  )
+  ModalBottomSheet(
+    onDismissRequest = onDismissRequest,
+    modifier = modifier,
+    sheetState = sheetState,
+    shape = shape,
+    containerColor = containerColor,
+    contentColor = contentColor,
+    tonalElevation = tonalElevation,
+    scrimColor = scrimColor,
+    dragHandle = dragHandle,
+    windowInsets = customWindowInsets,
+    content = content,
+  )
+}

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/MyBookDetailContainer.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/MyBookDetailContainer.kt
@@ -1,7 +1,6 @@
 package app.kaito_dogi.mybrary.feature.mybookdetail
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -12,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.kaito_dogi.mybrary.core.designsystem.component.FullScrimModalBottomSheet
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -34,7 +34,7 @@ internal fun MyBookDetailContainer(
     uiState = uiState,
     snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     bottomSheet = {
-      ModalBottomSheet(
+      FullScrimModalBottomSheet(
         onDismissRequest = viewModel::onBottomSheetDismissRequest,
         sheetState = bottomSheetState,
         content = it,


### PR DESCRIPTION
## :thought_balloon: 背景

- BottomSheet を表示したときに scrim がステータスバーの領域まで表示されていなかった

## :sparkles: 実装内容

- WindowInsets をカスタムし、scrim をステータスバーの領域まで表示できるようにした

## :white_check_mark: 動作確認

- [ ] `記入する`

## :art: UI 差分

| Before | After |
|:--:|:--:|
| <img src="https://github.com/Kaito-Dogi/mybrary/assets/49048577/f0b87470-8975-490f-908a-4e4675f23b75" width="300px" /> | <img src="https://github.com/Kaito-Dogi/mybrary/assets/49048577/b9de5845-8486-4f4e-9467-fe3a58d3f9dd" width="300px" /> |

## :link: 関連リンク

