### PR TITLE
MyBookListScreen でお気に入りの本とその他の本のセクションを分けた

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -46,4 +46,5 @@ dependencies {
   val composeBom = platform(libs.androidxComposeBom)
   implementation(composeBom)
   implementation(libs.androidxComposeMaterial3)
+  implementation(libs.androidxComposeUiTooling)
 }

--- a/core/designsystem/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/SkeletonBox.kt
+++ b/core/designsystem/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/SkeletonBox.kt
@@ -1,4 +1,4 @@
-package app.kaito_dogi.mybrary.core.ui.component
+package app.kaito_dogi.mybrary.core.designsystem.component
 
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat

--- a/core/designsystem/src/main/java/app/kaito_dogi/mybrary/core/designsystem/extension/FloatingActionButtonDefaultsExt.kt
+++ b/core/designsystem/src/main/java/app/kaito_dogi/mybrary/core/designsystem/extension/FloatingActionButtonDefaultsExt.kt
@@ -1,0 +1,13 @@
+package app.kaito_dogi.mybrary.core.designsystem.extension
+
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun FloatingActionButtonDefaults.elevationZero() = this.elevation(
+  defaultElevation = 0.dp,
+  pressedElevation = 0.dp,
+  focusedElevation = 0.dp,
+  hoveredElevation = 0.dp,
+)

--- a/core/designsystem/src/main/java/app/kaito_dogi/mybrary/core/designsystem/extension/PaddingValuesExt.kt
+++ b/core/designsystem/src/main/java/app/kaito_dogi/mybrary/core/designsystem/extension/PaddingValuesExt.kt
@@ -1,0 +1,52 @@
+package app.kaito_dogi.mybrary.core.designsystem.extension
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PaddingValues.plus(
+  all: Dp = 0.dp,
+): PaddingValues {
+  val layoutDirection = LocalLayoutDirection.current
+  return PaddingValues(
+    start = this.calculateStartPadding(layoutDirection) + all,
+    top = this.calculateTopPadding() + all,
+    end = this.calculateEndPadding(layoutDirection) + all,
+    bottom = this.calculateBottomPadding() + all,
+  )
+}
+
+@Composable
+fun PaddingValues.plus(
+  horizontal: Dp = 0.dp,
+  vertical: Dp = 0.dp,
+): PaddingValues {
+  val layoutDirection = LocalLayoutDirection.current
+  return PaddingValues(
+    start = this.calculateStartPadding(layoutDirection) + horizontal,
+    top = this.calculateTopPadding() + vertical,
+    end = this.calculateEndPadding(layoutDirection) + horizontal,
+    bottom = this.calculateBottomPadding() + vertical,
+  )
+}
+
+@Composable
+fun PaddingValues.plus(
+  start: Dp = 0.dp,
+  top: Dp = 0.dp,
+  end: Dp = 0.dp,
+  bottom: Dp = 0.dp,
+): PaddingValues {
+  val layoutDirection = LocalLayoutDirection.current
+  return PaddingValues(
+    start = this.calculateStartPadding(layoutDirection) + start,
+    top = this.calculateTopPadding() + top,
+    end = this.calculateEndPadding(layoutDirection) + end,
+    bottom = this.calculateBottomPadding() + bottom,
+  )
+}

--- a/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/component/BookImage.kt
+++ b/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/component/BookImage.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -24,6 +26,7 @@ fun BookImage(
   imageUrl: Url.Image,
   title: String,
   modifier: Modifier = Modifier,
+  shape: Shape = MybraryTheme.shapes.extraSmall,
   onLoading: ((AsyncImagePainter.State.Loading) -> Unit)? = null,
   onSuccess: ((AsyncImagePainter.State.Success) -> Unit)? = null,
   onError: ((AsyncImagePainter.State.Error) -> Unit)? = null,
@@ -35,7 +38,9 @@ fun BookImage(
   AsyncImage(
     model = imageUrl.value,
     contentDescription = "${title}の表紙",
-    modifier = modifier.aspectRatio(BookAspectRatio),
+    modifier = modifier
+      .clip(shape = shape)
+      .aspectRatio(BookAspectRatio),
     placeholder = painterResource(id = R.drawable.img_book_placeholder),
     error = painterResource(id = R.drawable.img_book_placeholder),
     onLoading = onLoading,

--- a/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/component/BookImage.kt
+++ b/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/component/BookImage.kt
@@ -41,8 +41,8 @@ fun BookImage(
     modifier = modifier
       .clip(shape = shape)
       .aspectRatio(BookAspectRatio),
-    placeholder = painterResource(id = R.drawable.img_book_placeholder),
-    error = painterResource(id = R.drawable.img_book_placeholder),
+    placeholder = painterResource(R.drawable.img_book_placeholder),
+    error = painterResource(R.drawable.img_book_placeholder),
     onLoading = onLoading,
     onSuccess = onSuccess,
     onError = onError,

--- a/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/component/SkeletonBox.kt
+++ b/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/component/SkeletonBox.kt
@@ -23,7 +23,7 @@ fun SkeletonBox(
   modifier: Modifier = Modifier,
   content: @Composable BoxScope.() -> Unit,
 ) {
-  val infiniteTransition = rememberInfiniteTransition(label = "")
+  val infiniteTransition = rememberInfiniteTransition(label = "スケルトン表示")
   val alpha by infiniteTransition.animateFloat(
     initialValue = 1.0f,
     targetValue = 0.2f,

--- a/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/component/SkeletonBox.kt
+++ b/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/component/SkeletonBox.kt
@@ -8,14 +8,18 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 
 @Composable
 fun SkeletonBox(
+  shape: Shape,
   modifier: Modifier = Modifier,
   content: @Composable BoxScope.() -> Unit,
 ) {
@@ -31,7 +35,9 @@ fun SkeletonBox(
   )
 
   Box(
-    modifier = modifier.background(MybraryTheme.colorScheme.surfaceVariant.copy(alpha = alpha)),
+    modifier = modifier
+      .clip(shape = shape)
+      .background(MybraryTheme.colorScheme.surfaceVariant.copy(alpha = alpha)),
     content = content,
   )
 }
@@ -40,6 +46,10 @@ fun SkeletonBox(
 @Composable
 private fun SkeletonBoxPreview() {
   MybraryTheme {
-    SkeletonBox {}
+    SkeletonBox(
+      shape = MybraryTheme.shapes.small,
+    ) {
+      Box(modifier = Modifier.size(MybraryTheme.space.xxxl))
+    }
   }
 }

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/MyBookDetailScreen.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/MyBookDetailScreen.kt
@@ -2,6 +2,7 @@ package app.kaito_dogi.mybrary.feature.mybookdetail
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -12,7 +13,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.common.model.Url
-import app.kaito_dogi.mybrary.core.designsystem.extension.plus
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.domain.model.BookId
 import app.kaito_dogi.mybrary.core.domain.model.ExternalBookId
@@ -56,10 +56,12 @@ internal fun MyBookDetailScreen(
     },
     snackbarHost = snackbarHost,
   ) { innerPadding ->
-    // ヘッダーを edge to edge で表示したいため、top は innerPadding の値を使用しない
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
-      contentPadding = innerPadding.plus(bottom = MybraryTheme.space.md),
+      // ヘッダーを edge to edge で表示したいため、top は innerPadding の値を使用しない
+      contentPadding = PaddingValues(
+        bottom = innerPadding.calculateBottomPadding() + MybraryTheme.space.md,
+      ),
       verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.md),
     ) {
       // ヘッダー

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/MyBookDetailScreen.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/MyBookDetailScreen.kt
@@ -3,9 +3,7 @@ package app.kaito_dogi.mybrary.feature.mybookdetail
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -46,7 +44,6 @@ internal fun MyBookDetailScreen(
   onSaveClick: () -> Unit,
 ) {
   Scaffold(
-    modifier = Modifier.fillMaxSize(),
     bottomBar = {
       MyBookDetailBottomAppBar(
         isPublic = uiState.myBook.isPublic,
@@ -62,14 +59,21 @@ internal fun MyBookDetailScreen(
     // ヘッダーを edge to edge で表示したいため、top は innerPadding の値を使用しない
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
-      contentPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding()),
+      contentPadding = PaddingValues(
+        bottom = MybraryTheme.space.md + innerPadding.calculateBottomPadding(),
+      ),
       verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.md),
     ) {
-      item {
+      // ヘッダー
+      item(
+        key = "MyBookDetailTopAppBar",
+      ) {
         MyBookDetailTopAppBar(
           myBook = uiState.myBook,
         )
       }
+
+      // メモ
       uiState.memoList?.let {
         items(
           items = uiState.memoList,
@@ -83,20 +87,20 @@ internal fun MyBookDetailScreen(
             ),
           )
         }
+      }
 
-        item {
-          // リストの1番下に Arrangement.spacedBy で余白をもたせるため、高さ0の要素を表示
-          Spacer(modifier = Modifier.fillMaxWidth())
+      // スケルトン表示
+      if (uiState.memoList == null) {
+        items(
+          count = 4,
+          key = { "MemoRowSkeleton$it" },
+        ) {
+          MemoRowSkeleton(
+            modifier = Modifier.padding(
+              horizontal = MybraryTheme.space.md,
+            ),
+          )
         }
-      } ?: items(
-        count = 4,
-        key = { "MemoRowSkeleton$it" },
-      ) {
-        MemoRowSkeleton(
-          modifier = Modifier.padding(
-            horizontal = MybraryTheme.space.md,
-          ),
-        )
       }
     }
 

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/MyBookDetailScreen.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/MyBookDetailScreen.kt
@@ -2,7 +2,6 @@ package app.kaito_dogi.mybrary.feature.mybookdetail
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -13,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.common.model.Url
+import app.kaito_dogi.mybrary.core.designsystem.extension.plus
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.domain.model.BookId
 import app.kaito_dogi.mybrary.core.domain.model.ExternalBookId
@@ -59,9 +59,7 @@ internal fun MyBookDetailScreen(
     // ヘッダーを edge to edge で表示したいため、top は innerPadding の値を使用しない
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
-      contentPadding = PaddingValues(
-        bottom = MybraryTheme.space.md + innerPadding.calculateBottomPadding(),
-      ),
+      contentPadding = innerPadding.plus(bottom = MybraryTheme.space.md),
       verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.md),
     ) {
       // ヘッダー

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRow.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRow.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,8 +27,6 @@ internal fun MemoRow(
   onClick: (Memo) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  val body = remember(memo) { memo.cardBody }
-
   Card(
     onClick = { onClick(memo) },
     modifier = modifier,
@@ -51,7 +48,7 @@ internal fun MemoRow(
       )
       Gap(height = MybraryTheme.space.xxs)
       Text(
-        text = body,
+        text = memo.cardBody,
         modifier = Modifier.fillMaxWidth(),
         // TODO: カラースキーマを整理する
         color = Color.Gray,

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRow.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRow.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -36,25 +37,25 @@ internal fun MemoRow(
   ) {
     // top の padding を小さくすることで、錯視を調整
     Column(
-      modifier = Modifier
-        .padding(
-          start = MybraryTheme.space.md,
-          top = MybraryTheme.space.sm,
-          end = MybraryTheme.space.md,
-          bottom = MybraryTheme.space.md,
-        )
-        .fillMaxWidth(),
+      modifier = Modifier.padding(
+        start = MybraryTheme.space.md,
+        top = MybraryTheme.space.sm,
+        end = MybraryTheme.space.md,
+        bottom = MybraryTheme.space.md,
+      ),
     ) {
       Text(
         text = memo.content,
         modifier = Modifier.fillMaxWidth(),
-        style = MybraryTheme.typography.titleMedium,
+        style = MybraryTheme.typography.bodyLarge,
       )
       Gap(height = MybraryTheme.space.xxs)
       Text(
         text = body,
         modifier = Modifier.fillMaxWidth(),
-        style = MybraryTheme.typography.bodyMedium,
+        // TODO: カラースキーマを整理する
+        color = Color.Gray,
+        style = MybraryTheme.typography.bodySmall,
       )
     }
   }

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRow.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRow.kt
@@ -138,5 +138,37 @@ private class PreviewMemoProvider : PreviewParameterProvider<Memo> {
         publishedAt = null,
         likeCount = null,
       ),
+      // 編集済みの場合
+      Memo(
+        id = MemoId(value = 0),
+        myBookId = MyBookId(value = 0),
+        user = User(
+          id = UserId(value = 0L),
+          name = "ユーザー名",
+        ),
+        content = "メモ",
+        fromPage = 1,
+        toPage = 100,
+        createdAt = LocalDateTime.now(),
+        updatedAt = LocalDateTime.now(),
+        publishedAt = null,
+        likeCount = null,
+      ),
+      // 複数行の場合
+      Memo(
+        id = MemoId(value = 0),
+        myBookId = MyBookId(value = 0),
+        user = User(
+          id = UserId(value = 0L),
+          name = "ユーザー名",
+        ),
+        content = "日本人はものをうまく作ることに取り憑かれている米国人はとにかく仕事を終えることを考える。",
+        fromPage = 1,
+        toPage = 100,
+        createdAt = LocalDateTime.now(),
+        updatedAt = null,
+        publishedAt = null,
+        likeCount = null,
+      ),
     )
 }

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRow.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRow.kt
@@ -32,7 +32,7 @@ internal fun MemoRow(
 
   Card(
     onClick = { onClick(memo) },
-    modifier = modifier.fillMaxWidth(),
+    modifier = modifier,
     shape = MybraryTheme.shapes.small,
   ) {
     // top の padding を小さくすることで、錯視を調整
@@ -107,7 +107,7 @@ private class PreviewMemoProvider : PreviewParameterProvider<Memo> {
         publishedAt = null,
         likeCount = null,
       ),
-      // 開始ページのみが記録されている場合
+      // 片方のページのみが記録されている場合
       Memo(
         id = MemoId(value = 0),
         myBookId = MyBookId(value = 0),

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRowSkeleton.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRowSkeleton.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.component.Gap
+import app.kaito_dogi.mybrary.core.designsystem.component.SkeletonBox
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
-import app.kaito_dogi.mybrary.core.ui.component.SkeletonBox
 
 @Composable
 internal fun MemoRowSkeleton(

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRowSkeleton.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRowSkeleton.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.component.Gap
@@ -18,9 +17,8 @@ internal fun MemoRowSkeleton(
   modifier: Modifier = Modifier,
 ) {
   SkeletonBox(
-    modifier = modifier
-      .clip(shape = MybraryTheme.shapes.small)
-      .fillMaxWidth(),
+    shape = MybraryTheme.shapes.small,
+    modifier = modifier,
   ) {
     Column(
       modifier = modifier.padding(

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRowSkeleton.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MemoRowSkeleton.kt
@@ -23,27 +23,25 @@ internal fun MemoRowSkeleton(
       .fillMaxWidth(),
   ) {
     Column(
-      modifier = modifier
-        .padding(
-          start = MybraryTheme.space.md,
-          top = MybraryTheme.space.sm,
-          end = MybraryTheme.space.md,
-          bottom = MybraryTheme.space.md,
-        )
-        .fillMaxWidth(),
+      modifier = modifier.padding(
+        start = MybraryTheme.space.md,
+        top = MybraryTheme.space.sm,
+        end = MybraryTheme.space.md,
+        bottom = MybraryTheme.space.md,
+      ),
     ) {
       Text(
         text = "あ",
         modifier = Modifier.fillMaxWidth(),
         color = Color.Transparent,
-        style = MybraryTheme.typography.titleMedium,
+        style = MybraryTheme.typography.bodyLarge,
       )
       Gap(height = MybraryTheme.space.xxs)
       Text(
         text = "あ",
         modifier = Modifier.fillMaxWidth(),
         color = Color.Transparent,
-        style = MybraryTheme.typography.bodyMedium,
+        style = MybraryTheme.typography.bodySmall,
       )
     }
   }

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailBottomAppBar.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailBottomAppBar.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import app.kaito_dogi.mybrary.core.designsystem.extension.elevationZero
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.R
 
@@ -62,12 +62,7 @@ internal fun MyBookDetailBottomAppBar(
     Spacer(modifier = Modifier.weight(1f))
     FloatingActionButton(
       onClick = onAdditionClick,
-      elevation = FloatingActionButtonDefaults.elevation(
-        defaultElevation = 0.dp,
-        pressedElevation = 0.dp,
-        focusedElevation = 0.dp,
-        hoveredElevation = 0.dp,
-      ),
+      elevation = FloatingActionButtonDefaults.elevationZero(),
     ) {
       Icon(
         painter = painterResource(R.drawable.icon_add),

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailBottomAppBar.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailBottomAppBar.kt
@@ -2,7 +2,6 @@ package app.kaito_dogi.mybrary.feature.mybookdetail.component
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
@@ -27,7 +26,7 @@ internal fun MyBookDetailBottomAppBar(
   modifier: Modifier = Modifier,
 ) {
   BottomAppBar(
-    modifier = modifier.fillMaxWidth(),
+    modifier = modifier,
     contentPadding = PaddingValues(
       start = MybraryTheme.space.xxs,
       end = MybraryTheme.space.md,

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailBottomAppBar.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailBottomAppBar.kt
@@ -36,16 +36,16 @@ internal fun MyBookDetailBottomAppBar(
     // TODO: v2 以降で実装を復活させる
 //    IconButton(onClick = onArchiveClick) {
 //      Icon(
-//        painter = painterResource(id = R.drawable.icon_archive),
+//        painter = painterResource(R.drawable.icon_archive),
 //        contentDescription = "書籍を非表示にする",
 //      )
 //    }
 //    IconButton(onClick = onPublicClick) {
 //      Icon(
 //        painter = if (isPublic) {
-//          painterResource(id = R.drawable.icon_visibility)
+//          painterResource(R.drawable.icon_visibility)
 //        } else {
-//          painterResource(id = R.drawable.icon_visibility_off)
+//          painterResource(R.drawable.icon_visibility_off)
 //        },
 //        contentDescription = "書籍を他のユーザーに公開する",
 //      )
@@ -53,9 +53,9 @@ internal fun MyBookDetailBottomAppBar(
     IconButton(onClick = onFavoriteClick) {
       Icon(
         painter = if (isFavorite) {
-          painterResource(id = R.drawable.icon_heart_filled)
+          painterResource(R.drawable.icon_heart_filled)
         } else {
-          painterResource(id = R.drawable.icon_heart_outlined)
+          painterResource(R.drawable.icon_heart_outlined)
         },
         contentDescription = "書籍をお気に入り登録する",
       )
@@ -71,7 +71,7 @@ internal fun MyBookDetailBottomAppBar(
       ),
     ) {
       Icon(
-        painter = painterResource(id = R.drawable.icon_add),
+        painter = painterResource(R.drawable.icon_add),
         contentDescription = "メモを編集",
       )
     }

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailBottomSheetContent.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailBottomSheetContent.kt
@@ -22,6 +22,8 @@ import app.kaito_dogi.mybrary.core.domain.model.DraftMemo
 import app.kaito_dogi.mybrary.core.domain.model.MyBookId
 import app.kaito_dogi.mybrary.core.ui.R
 
+private const val Radix = 10
+
 @Composable
 internal fun MyBookDetailBottomSheetContent(
   draftMemo: DraftMemo,
@@ -32,10 +34,10 @@ internal fun MyBookDetailBottomSheetContent(
   onSaveClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  Column(modifier = modifier.fillMaxWidth()) {
+  Column(modifier = modifier) {
     Row(modifier = Modifier.fillMaxWidth()) {
       TextField(
-        value = if (draftMemo.fromPage == null) "" else draftMemo.fromPage.toString(),
+        value = draftMemo.fromPage?.toString(radix = Radix) ?: "",
         onValueChange = onFromPageChange,
         modifier = Modifier.weight(1f),
         placeholder = { Text(text = "開始ページ") },
@@ -46,7 +48,7 @@ internal fun MyBookDetailBottomSheetContent(
       )
       Gap(width = MybraryTheme.space.sm)
       TextField(
-        value = if (draftMemo.toPage == null) "" else draftMemo.toPage.toString(),
+        value = draftMemo.toPage?.toString(radix = Radix) ?: "",
         onValueChange = onToPageChange,
         modifier = Modifier.weight(1f),
         placeholder = { Text(text = "終了ページ") },
@@ -67,20 +69,15 @@ internal fun MyBookDetailBottomSheetContent(
         modifier = Modifier.weight(1f),
         placeholder = { Text(text = "メモを入力…") },
         isError = isContentTextFieldError,
-        keyboardOptions = KeyboardOptions.Default.copy(
-          keyboardType = KeyboardType.Text,
-          imeAction = ImeAction.Send,
-        ),
+        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Text),
         keyboardActions = KeyboardActions(
-          onSend = {
-            onSaveClick()
-          },
+          onSend = { onSaveClick() },
         ),
         minLines = 2,
       )
       IconButton(onClick = onSaveClick) {
         Icon(
-          painter = painterResource(id = R.drawable.icon_send),
+          painter = painterResource(R.drawable.icon_send),
           contentDescription = "メモを保存する",
         )
       }
@@ -88,7 +85,7 @@ internal fun MyBookDetailBottomSheetContent(
   }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun MyBookDetailBottomSheetContentPreview() {
   MybraryTheme {

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailTopAppBar.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailTopAppBar.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,7 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.layout.ContentScale
@@ -53,15 +52,11 @@ internal fun MyBookDetailTopAppBar(
   myBook: MyBook,
   modifier: Modifier = Modifier,
 ) {
-  Box(
-    modifier = modifier
-      .fillMaxWidth()
-      .height(IntrinsicSize.Min),
-  ) {
+  Box(modifier = modifier.height(IntrinsicSize.Min)) {
     AsyncImage(
       model = myBook.imageUrl.value,
       modifier = Modifier
-        .fillMaxHeight()
+        .matchParentSize()
         .background(MybraryTheme.colorScheme.primary)
         .blur(
           radiusX = MybraryTheme.space.md,
@@ -71,59 +66,59 @@ internal fun MyBookDetailTopAppBar(
       contentScale = ContentScale.FillWidth,
       colorFilter = ColorFilter.colorMatrix(ColorMatrix(ColorMatrix)),
     )
-    Column(
-      modifier = modifier.padding(MybraryTheme.space.md),
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .height(IntrinsicSize.Min)
+        .padding(
+          start = MybraryTheme.space.md,
+          top = MybraryTheme.space.md + WindowInsets.systemBars
+            .asPaddingValues()
+            .calculateTopPadding(),
+          end = MybraryTheme.space.md,
+          bottom = MybraryTheme.space.md,
+        ),
     ) {
-      Gap(height = WindowInsets.systemBars.asPaddingValues().calculateTopPadding())
-      Row(
-        modifier = Modifier
-          .fillMaxWidth()
-          .height(IntrinsicSize.Min),
+      // TODO: width を定数にする
+      BookImage(
+        imageUrl = myBook.imageUrl,
+        title = myBook.title,
+        modifier = Modifier.width(120.dp),
+      )
+      Gap(width = MybraryTheme.space.md)
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xs),
       ) {
-        BookImage(
-          imageUrl = myBook.imageUrl,
-          title = myBook.title,
+        Text(
+          text = myBook.title,
           modifier = Modifier
-            .width(120.dp) // TODO: 定数にする
-            .clip(shape = MybraryTheme.shapes.extraSmall),
-        )
-        Gap(width = MybraryTheme.space.md)
-        Column(
-          modifier = Modifier
-            .fillMaxHeight()
+            .fillMaxWidth()
             .weight(1f),
-          verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xs),
-        ) {
+          color = Color.White,
+          overflow = TextOverflow.Ellipsis,
+          maxLines = 4,
+          style = MybraryTheme.typography.titleMedium,
+        )
+        if (myBook.authors.isNotEmpty()) {
           Text(
-            text = myBook.title,
-            modifier = Modifier
-              .fillMaxWidth()
-              .weight(1f),
-            color = MybraryTheme.colorScheme.onPrimary,
+            text = myBook.authors.joinToString { it.name },
+            modifier = Modifier.fillMaxWidth(),
+            color = Color.White,
             overflow = TextOverflow.Ellipsis,
-            maxLines = 4,
-            style = MybraryTheme.typography.titleMedium,
+            maxLines = 2,
+            style = MybraryTheme.typography.bodyMedium,
           )
-          if (myBook.authors.isNotEmpty()) {
-            Text(
-              text = myBook.authors.joinToString { it.name },
-              modifier = Modifier.fillMaxWidth(),
-              color = MybraryTheme.colorScheme.onPrimary,
-              overflow = TextOverflow.Ellipsis,
-              maxLines = 2,
-              style = MybraryTheme.typography.bodyMedium,
-            )
-          }
-          if (myBook.topAppBarBody.isNotBlank()) {
-            Text(
-              text = myBook.topAppBarBody,
-              modifier = Modifier.fillMaxWidth(),
-              color = MybraryTheme.colorScheme.onPrimary,
-              overflow = TextOverflow.Ellipsis,
-              maxLines = 1,
-              style = MybraryTheme.typography.bodyMedium,
-            )
-          }
+        }
+        if (myBook.topAppBarBody.isNotBlank()) {
+          Text(
+            text = myBook.topAppBarBody,
+            modifier = Modifier.fillMaxWidth(),
+            color = Color.White,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            style = MybraryTheme.typography.bodyMedium,
+          )
         }
       }
     }

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailTopAppBar.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailTopAppBar.kt
@@ -96,7 +96,7 @@ internal fun MyBookDetailTopAppBar(
           color = Color.White,
           overflow = TextOverflow.Ellipsis,
           maxLines = 4,
-          style = MybraryTheme.typography.titleMedium,
+          style = MybraryTheme.typography.titleLarge,
         )
         if (myBook.authors.isNotEmpty()) {
           Text(

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailTopAppBar.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailTopAppBar.kt
@@ -85,7 +85,9 @@ internal fun MyBookDetailTopAppBar(
         modifier = Modifier.width(120.dp),
       )
       Gap(width = MybraryTheme.space.md)
-      Column(verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xs)) {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xs),
+      ) {
         Text(
           text = myBook.title,
           modifier = Modifier

--- a/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailTopAppBar.kt
+++ b/feature/mybookdetail/src/main/java/app/kaito_dogi/mybrary/feature/mybookdetail/component/MyBookDetailTopAppBar.kt
@@ -68,7 +68,6 @@ internal fun MyBookDetailTopAppBar(
     )
     Row(
       modifier = Modifier
-        .fillMaxWidth()
         .height(IntrinsicSize.Min)
         .padding(
           start = MybraryTheme.space.md,
@@ -86,10 +85,7 @@ internal fun MyBookDetailTopAppBar(
         modifier = Modifier.width(120.dp),
       )
       Gap(width = MybraryTheme.space.md)
-      Column(
-        modifier = Modifier.weight(1f),
-        verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xs),
-      ) {
+      Column(verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xs)) {
         Text(
           text = myBook.title,
           modifier = Modifier

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListScreen.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListScreen.kt
@@ -2,7 +2,6 @@ package app.kaito_dogi.mybrary.feature.mybooklist
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -18,6 +17,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.extension.plus
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.domain.model.MyBook
 import app.kaito_dogi.mybrary.feature.mybooklist.component.MyBookCell
@@ -47,11 +47,11 @@ internal fun MyBookListScreen(
     LazyVerticalGrid(
       columns = GridCells.Fixed(uiState.numberOfColumns),
       modifier = Modifier.fillMaxSize(),
-      contentPadding = PaddingValues(
+      contentPadding = innerPadding.plus(
         start = MybraryTheme.space.md,
-        top = MybraryTheme.space.sm + innerPadding.calculateTopPadding(),
+        top = MybraryTheme.space.sm,
         end = MybraryTheme.space.md,
-        bottom = MybraryTheme.space.md + innerPadding.calculateBottomPadding(),
+        bottom = MybraryTheme.space.md,
       ),
       verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.sm),
       horizontalArrangement = Arrangement.spacedBy(MybraryTheme.space.sm),

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListScreen.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListScreen.kt
@@ -43,7 +43,7 @@ internal fun MyBookListScreen(
       modifier = Modifier.fillMaxSize(),
       contentPadding = PaddingValues(
         start = MybraryTheme.space.md,
-        top = innerPadding.calculateTopPadding(),
+        top = MybraryTheme.space.sm + innerPadding.calculateTopPadding(),
         end = MybraryTheme.space.md,
         bottom = innerPadding.calculateBottomPadding(),
       ),

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListScreen.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListScreen.kt
@@ -1,9 +1,13 @@
 package app.kaito_dogi.mybrary.feature.mybooklist
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
@@ -18,7 +22,10 @@ import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.domain.model.MyBook
 import app.kaito_dogi.mybrary.feature.mybooklist.component.MyBookCell
 import app.kaito_dogi.mybrary.feature.mybooklist.component.MyBookCellSkeleton
+import app.kaito_dogi.mybrary.feature.mybooklist.component.MyBookListHeader
+import app.kaito_dogi.mybrary.feature.mybooklist.component.MyBookListHeaderSkeleton
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun MyBookListScreen(
   uiState: MyBookListUiState,
@@ -50,21 +57,70 @@ internal fun MyBookListScreen(
       verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.sm),
       horizontalArrangement = Arrangement.spacedBy(MybraryTheme.space.sm),
     ) {
-      uiState.myBookList?.let {
+      // お気に入りの本
+      uiState.favoriteMyBookList?.let { favoriteMyBookList ->
+        if (favoriteMyBookList.isNotEmpty()) {
+          item(
+            span = { GridItemSpan(uiState.numberOfColumns) },
+            key = "MyBookListHeader:お気に入りの本",
+          ) {
+            MyBookListHeader(title = "お気に入りの本")
+          }
+          items(
+            items = favoriteMyBookList,
+            key = { it.id.value },
+          ) { favoriteMyBook ->
+            MyBookCell(
+              myBook = favoriteMyBook,
+              onClick = onMyBookClick,
+              modifier = Modifier.animateItemPlacement(),
+            )
+          }
+          item(
+            span = { GridItemSpan(uiState.numberOfColumns) },
+            key = "Spacer:お気に入りの本",
+          ) {
+            Spacer(modifier = Modifier.height(MybraryTheme.space.xxl))
+          }
+        }
+      }
+
+      // その他の本
+      uiState.otherMyBookList?.let { unfavoriteMyBookList ->
+        if (unfavoriteMyBookList.isNotEmpty() && !uiState.areAllMyBooksInOtherList) {
+          item(
+            span = { GridItemSpan(uiState.numberOfColumns) },
+            key = "MyBookListHeader:その他の本",
+          ) {
+            MyBookListHeader(title = "その他の本")
+          }
+        }
         items(
-          items = uiState.myBookList,
+          items = unfavoriteMyBookList,
           key = { it.id.value },
-        ) {
+        ) { unfavoriteMyBook ->
           MyBookCell(
-            myBook = it,
+            myBook = unfavoriteMyBook,
             onClick = onMyBookClick,
+            modifier = Modifier.animateItemPlacement(),
           )
         }
-      } ?: items(
-        count = 4,
-        key = { "MyBookCellSkeleton$it" },
-      ) {
-        MyBookCellSkeleton()
+      }
+
+      // スケルトン表示
+      if (uiState.myBookList == null) {
+        item(
+          span = { GridItemSpan(uiState.numberOfColumns) },
+          key = "MyBookListHeaderSkeleton",
+        ) {
+          MyBookListHeaderSkeleton()
+        }
+        items(
+          count = 4,
+          key = { "MyBookCellSkeleton$it" },
+        ) {
+          MyBookCellSkeleton()
+        }
       }
     }
   }

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListScreen.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListScreen.kt
@@ -33,7 +33,6 @@ internal fun MyBookListScreen(
   onMyBookClick: (MyBook) -> Unit,
 ) {
   Scaffold(
-    modifier = Modifier.fillMaxSize(),
     floatingActionButton = {
       FloatingActionButton(
         onClick = onAdditionClick,
@@ -52,7 +51,7 @@ internal fun MyBookListScreen(
         start = MybraryTheme.space.md,
         top = MybraryTheme.space.sm + innerPadding.calculateTopPadding(),
         end = MybraryTheme.space.md,
-        bottom = innerPadding.calculateBottomPadding(),
+        bottom = MybraryTheme.space.md + innerPadding.calculateBottomPadding(),
       ),
       verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.sm),
       horizontalArrangement = Arrangement.spacedBy(MybraryTheme.space.sm),
@@ -62,7 +61,7 @@ internal fun MyBookListScreen(
         if (favoriteMyBookList.isNotEmpty()) {
           item(
             span = { GridItemSpan(uiState.numberOfColumns) },
-            key = "MyBookListHeader:お気に入りの本",
+            key = "MyBookListHeader:favorite",
           ) {
             MyBookListHeader(title = "お気に入りの本")
           }
@@ -78,7 +77,7 @@ internal fun MyBookListScreen(
           }
           item(
             span = { GridItemSpan(uiState.numberOfColumns) },
-            key = "Spacer:お気に入りの本",
+            key = "Spacer:favorite",
           ) {
             Spacer(modifier = Modifier.height(MybraryTheme.space.xxl))
           }
@@ -86,21 +85,27 @@ internal fun MyBookListScreen(
       }
 
       // その他の本
-      uiState.otherMyBookList?.let { unfavoriteMyBookList ->
-        if (unfavoriteMyBookList.isNotEmpty() && !uiState.areAllMyBooksInOtherList) {
+      uiState.otherMyBookList?.let { otherMyBookList ->
+        if (otherMyBookList.isNotEmpty()) {
           item(
             span = { GridItemSpan(uiState.numberOfColumns) },
-            key = "MyBookListHeader:その他の本",
+            key = "MyBookListHeader:other",
           ) {
-            MyBookListHeader(title = "その他の本")
+            MyBookListHeader(
+              title = if (uiState.areAllMyBooksInOtherList) {
+                "すべての本"
+              } else {
+                "その他の本"
+              },
+            )
           }
         }
         items(
-          items = unfavoriteMyBookList,
+          items = otherMyBookList,
           key = { it.id.value },
-        ) { unfavoriteMyBook ->
+        ) { otherMyBook ->
           MyBookCell(
-            myBook = unfavoriteMyBook,
+            myBook = otherMyBook,
             onClick = onMyBookClick,
             modifier = Modifier.animateItemPlacement(),
           )

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListUiState.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/MyBookListUiState.kt
@@ -10,6 +10,10 @@ internal data class MyBookListUiState(
   val numberOfColumns: Int,
   val myBookList: List<MyBook>?,
 ) {
+  val favoriteMyBookList: List<MyBook>? = myBookList?.filter { it.isFavorite }
+  val otherMyBookList: List<MyBook>? = myBookList?.filterNot { it.isFavorite }
+  val areAllMyBooksInOtherList: Boolean = otherMyBookList == myBookList
+
   companion object {
     val InitialValue = MyBookListUiState(
       numberOfColumns = NumberOfColumns,

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookCellSkeleton.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookCellSkeleton.kt
@@ -3,7 +3,6 @@ package app.kaito_dogi.mybrary.feature.mybooklist.component
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.component.BookAspectRatio
@@ -15,9 +14,8 @@ internal fun MyBookCellSkeleton(
   modifier: Modifier = Modifier,
 ) {
   SkeletonBox(
-    modifier = modifier
-      .clip(shape = MybraryTheme.shapes.extraSmall)
-      .aspectRatio(BookAspectRatio),
+    shape = MybraryTheme.shapes.extraSmall,
+    modifier = modifier.aspectRatio(BookAspectRatio),
   ) {
     // 何も表示しない
   }

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookCellSkeleton.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookCellSkeleton.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.component.SkeletonBox
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.component.BookAspectRatio
-import app.kaito_dogi.mybrary.core.ui.component.SkeletonBox
 
 
 @Composable

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeader.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeader.kt
@@ -1,0 +1,29 @@
+package app.kaito_dogi.mybrary.feature.mybooklist.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+internal fun MyBookListHeader(
+  title: String,
+  modifier: Modifier = Modifier,
+) {
+  Text(
+    text = title,
+    modifier = modifier.fillMaxWidth(),
+    color = MybraryTheme.colorScheme.onBackground,
+    style = MybraryTheme.typography.headlineMedium,
+  )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MyBookListHeaderPreview() {
+  MybraryTheme {
+    MyBookListHeader(title = "タイトル")
+  }
+}

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeaderSkeleton.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeaderSkeleton.kt
@@ -1,0 +1,36 @@
+package app.kaito_dogi.mybrary.feature.mybooklist.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+import app.kaito_dogi.mybrary.core.ui.component.SkeletonBox
+
+@Composable
+internal fun MyBookListHeaderSkeleton(
+  modifier: Modifier = Modifier,
+) {
+  SkeletonBox(
+    modifier = modifier
+      .fillMaxWidth()
+      .clip(MybraryTheme.shapes.extraSmall),
+  ) {
+    Text(
+      text = "あ",
+      color = Color.Transparent,
+      style = MybraryTheme.typography.headlineMedium,
+    )
+  }
+}
+
+@Preview
+@Composable
+private fun MyBookListHeaderSkeletonPreview() {
+  MybraryTheme {
+    MyBookListHeaderSkeleton()
+  }
+}

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeaderSkeleton.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeaderSkeleton.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.component.SkeletonBox
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
-import app.kaito_dogi.mybrary.core.ui.component.SkeletonBox
 
 @Composable
 internal fun MyBookListHeaderSkeleton(

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeaderSkeleton.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeaderSkeleton.kt
@@ -17,7 +17,7 @@ internal fun MyBookListHeaderSkeleton(
   SkeletonBox(
     modifier = modifier
       .fillMaxWidth()
-      .clip(MybraryTheme.shapes.extraSmall),
+      .clip(shape = MybraryTheme.shapes.extraSmall),
   ) {
     Text(
       text = "あ",

--- a/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeaderSkeleton.kt
+++ b/feature/mybooklist/src/main/java/app/kaito_dogi/mybrary/feature/mybooklist/component/MyBookListHeaderSkeleton.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
@@ -15,12 +14,12 @@ internal fun MyBookListHeaderSkeleton(
   modifier: Modifier = Modifier,
 ) {
   SkeletonBox(
-    modifier = modifier
-      .fillMaxWidth()
-      .clip(shape = MybraryTheme.shapes.extraSmall),
+    shape = MybraryTheme.shapes.extraSmall,
+    modifier = modifier,
   ) {
     Text(
       text = "あ",
+      modifier = Modifier.fillMaxWidth(),
       color = Color.Transparent,
       style = MybraryTheme.typography.headlineMedium,
     )

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/SearchBookContainer.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/SearchBookContainer.kt
@@ -30,7 +30,7 @@ internal fun SearchBookContainer(
     },
     onSearchQueryChange = viewModel::onSearchQueryChange,
     onBarcodeScannerClick = {},
-    // TODO: v2 以降で実装を差し替える
+    // TODO: v2 以降で Click の実装を差し替える
     onSearchResultClick = viewModel::onSearchResultBookLongClick,
     onSearchResultLongClick = viewModel::onSearchResultBookLongClick,
   )

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/SearchBookScreen.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/SearchBookScreen.kt
@@ -46,7 +46,7 @@ internal fun SearchBookScreen(
       modifier = Modifier.fillMaxSize(),
       contentPadding = PaddingValues(
         start = MybraryTheme.space.md,
-        top = innerPadding.calculateTopPadding(),
+        top = MybraryTheme.space.md + innerPadding.calculateTopPadding(),
         end = MybraryTheme.space.md,
         bottom = innerPadding.calculateBottomPadding(),
       ),

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/SearchBookScreen.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/SearchBookScreen.kt
@@ -2,10 +2,8 @@ package app.kaito_dogi.mybrary.feature.searchbook
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -48,7 +46,7 @@ internal fun SearchBookScreen(
         start = MybraryTheme.space.md,
         top = MybraryTheme.space.md + innerPadding.calculateTopPadding(),
         end = MybraryTheme.space.md,
-        bottom = innerPadding.calculateBottomPadding(),
+        bottom = MybraryTheme.space.md + innerPadding.calculateBottomPadding(),
       ),
       verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.md),
     ) {
@@ -62,11 +60,6 @@ internal fun SearchBookScreen(
             onClick = onSearchResultClick,
             onLongClick = onSearchResultLongClick,
           )
-        }
-
-        item {
-          // リストの1番下に Arrangement.spacedBy で余白をもたせるため、高さ0の要素を表示
-          Spacer(modifier = Modifier.fillMaxWidth())
         }
       }
 

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/SearchBookScreen.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/SearchBookScreen.kt
@@ -1,7 +1,6 @@
 package app.kaito_dogi.mybrary.feature.searchbook
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.ime
@@ -13,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.extension.plus
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.domain.model.SearchResultBook
 import app.kaito_dogi.mybrary.feature.searchbook.component.SearchBookBottomAppBar
@@ -42,11 +42,11 @@ internal fun SearchBookScreen(
   ) { innerPadding ->
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
-      contentPadding = PaddingValues(
+      contentPadding = innerPadding.plus(
         start = MybraryTheme.space.md,
-        top = MybraryTheme.space.md + innerPadding.calculateTopPadding(),
+        top = MybraryTheme.space.sm,
         end = MybraryTheme.space.md,
-        bottom = MybraryTheme.space.md + innerPadding.calculateBottomPadding(),
+        bottom = MybraryTheme.space.md,
       ),
       verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.md),
     ) {

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchBookBottomAppBar.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchBookBottomAppBar.kt
@@ -1,7 +1,6 @@
 package app.kaito_dogi.mybrary.feature.searchbook.component
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
@@ -23,7 +22,7 @@ internal fun SearchBookBottomAppBar(
   modifier: Modifier = Modifier,
 ) {
   BottomAppBar(
-    modifier = modifier.fillMaxWidth(),
+    modifier = modifier,
     contentPadding = PaddingValues(horizontal = MybraryTheme.space.md),
   ) {
     TextField(
@@ -33,13 +32,11 @@ internal fun SearchBookBottomAppBar(
       placeholder = { Text(text = "検索ワードを入力…") },
       leadingIcon = {
         Icon(
-          painter = painterResource(id = R.drawable.icon_search),
+          painter = painterResource(R.drawable.icon_search),
           contentDescription = "書籍一覧画面に戻る",
         )
       },
-      keyboardOptions = KeyboardOptions.Default.copy(
-        imeAction = ImeAction.Done,
-      ),
+      keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
     )
     // TODO: v2 以降で実装する
 //    Gap(width = MybraryTheme.space.sm)
@@ -53,7 +50,7 @@ internal fun SearchBookBottomAppBar(
 //      ),
 //    ) {
 //      Icon(
-//        painter = painterResource(id = R.drawable.icon_barcode_scanner),
+//        painter = painterResource(R.drawable.icon_barcode_scanner),
 //        contentDescription = "バーコードを読み取る",
 //      )
 //    }

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchBookBottomAppBar.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchBookBottomAppBar.kt
@@ -44,12 +44,7 @@ internal fun SearchBookBottomAppBar(
 //    Gap(width = MybraryTheme.space.sm)
 //    FloatingActionButton(
 //      onClick = onBarcodeScannerClick,
-//      elevation = FloatingActionButtonDefaults.elevation(
-//        defaultElevation = 0.dp,
-//        pressedElevation = 0.dp,
-//        focusedElevation = 0.dp,
-//        hoveredElevation = 0.dp,
-//      ),
+//      elevation = FloatingActionButtonDefaults.elevationZero(),
 //    ) {
 //      Icon(
 //        painter = painterResource(R.drawable.icon_barcode_scanner),

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchBookBottomAppBar.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchBookBottomAppBar.kt
@@ -36,7 +36,9 @@ internal fun SearchBookBottomAppBar(
           contentDescription = "書籍一覧画面に戻る",
         )
       },
-      keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+      keyboardOptions = KeyboardOptions.Default.copy(
+        imeAction = ImeAction.Done,
+      ),
     )
     // TODO: v2 以降で実装する
 //    Gap(width = MybraryTheme.space.sm)

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRow.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRow.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -46,20 +45,16 @@ internal fun SearchResultBookRow(
     Row(
       modifier = Modifier
         .padding(MybraryTheme.space.md)
-        .fillMaxWidth()
         .height(IntrinsicSize.Min),
     ) {
+      // TODO: 定数にする
       BookImage(
         imageUrl = searchResultBook.imageUrl,
         title = searchResultBook.title,
-        modifier = Modifier
-          .width(72.dp) // TODO: 定数にする
-          .clip(shape = MybraryTheme.shapes.extraSmall),
+        modifier = Modifier.width(72.dp),
       )
       Gap(width = MybraryTheme.space.sm)
-      Column(
-        verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs),
-      ) {
+      Column(verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs)) {
         Text(
           text = searchResultBook.title,
           modifier = Modifier

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRow.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRow.kt
@@ -54,7 +54,9 @@ internal fun SearchResultBookRow(
         modifier = Modifier.width(72.dp),
       )
       Gap(width = MybraryTheme.space.sm)
-      Column(verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs)) {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs),
+      ) {
         Text(
           text = searchResultBook.title,
           modifier = Modifier

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRowSkeleton.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRowSkeleton.kt
@@ -39,7 +39,9 @@ fun SearchResultBookRowSkeleton(
           .aspectRatio(BookAspectRatio)
           .width(72.dp),
       )
-      Column(verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs)) {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs),
+      ) {
         Text(
           text = "あ\nあ",
           modifier = Modifier.fillMaxWidth(),

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRowSkeleton.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRowSkeleton.kt
@@ -16,9 +16,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import app.kaito_dogi.mybrary.core.designsystem.component.SkeletonBox
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.component.BookAspectRatio
-import app.kaito_dogi.mybrary.core.ui.component.SkeletonBox
 
 @Composable
 fun SearchResultBookRowSkeleton(

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRowSkeleton.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRowSkeleton.kt
@@ -13,9 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
@@ -27,46 +25,40 @@ fun SearchResultBookRowSkeleton(
   modifier: Modifier = Modifier,
 ) {
   SkeletonBox(
-    modifier = modifier
-      .clip(shape = MybraryTheme.shapes.small)
-      .fillMaxWidth(),
+    shape = MybraryTheme.shapes.small,
+    modifier = modifier,
   ) {
     Row(
       modifier = Modifier
         .padding(MybraryTheme.space.md)
-        .fillMaxWidth()
         .height(IntrinsicSize.Min),
     ) {
+      // TODO: width を定数化する
       Box(
         modifier = Modifier
           .aspectRatio(BookAspectRatio)
           .width(72.dp),
       )
       Column(
+        modifier = Modifier.weight(1f),
         verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs),
       ) {
         Text(
           text = "あ\nあ",
           modifier = Modifier.fillMaxWidth(),
           color = Color.Transparent,
-          overflow = TextOverflow.Ellipsis,
-          maxLines = 2,
           style = MybraryTheme.typography.titleMedium,
         )
         Text(
           text = "あ",
           modifier = Modifier.fillMaxWidth(),
           color = Color.Transparent,
-          overflow = TextOverflow.Ellipsis,
-          maxLines = 1,
           style = MybraryTheme.typography.bodyMedium,
         )
         Text(
           text = "あ",
           modifier = Modifier.fillMaxWidth(),
           color = Color.Transparent,
-          overflow = TextOverflow.Ellipsis,
-          maxLines = 1,
           style = MybraryTheme.typography.bodyMedium,
         )
       }

--- a/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRowSkeleton.kt
+++ b/feature/searchbook/src/main/java/app/kaito_dogi/mybrary/feature/searchbook/component/SearchResultBookRowSkeleton.kt
@@ -39,10 +39,7 @@ fun SearchResultBookRowSkeleton(
           .aspectRatio(BookAspectRatio)
           .width(72.dp),
       )
-      Column(
-        modifier = Modifier.weight(1f),
-        verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs),
-      ) {
+      Column(verticalArrangement = Arrangement.spacedBy(MybraryTheme.space.xxs)) {
         Text(
           text = "あ\nあ",
           modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## :thought_balloon: 背景


## :sparkles: 実装内容


## :white_check_mark: 動作確認

- [ ] `記入する`

## :art: UI 差分

| MyBookList お気に入りナシ | MyBookList お気に入りアリ | MyBookDetail |
|:--:|:--:|:--:|
| <img src="https://github.com/Kaito-Dogi/mybrary/assets/49048577/44b89dc8-f1c1-48ca-ab4f-a87f79c9566b" width="300px" /> | <img src="https://github.com/Kaito-Dogi/mybrary/assets/49048577/26847b32-e987-4383-9144-2ca708afad27" width="300px" /> | <img src="https://github.com/Kaito-Dogi/mybrary/assets/49048577/b7069c97-9cd3-447b-b787-7eee71756c61" width="300px" /> |

## :link: 関連リンク

