### PR TITLE
PrimaryButton と SecondaryButton を作成

### DIFF
--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/PrimaryButton.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/PrimaryButton.kt
@@ -1,0 +1,93 @@
+package app.kaito_dogi.mybrary.core.designsystem.component
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+fun PrimaryButton(
+  @StringRes textResId: Int,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  @DrawableRes iconResId: Int? = null,
+  @StringRes altResId: Int? = null,
+  isLoading: Boolean = false,
+  isEnabled: Boolean = true,
+) = androidx.compose.material3.Button(
+  onClick = onClick,
+  modifier = modifier,
+  enabled = isEnabled && !isLoading,
+) {
+  if (iconResId != null && !isLoading) {
+    Icon(
+      iconResId = iconResId,
+      altResId = altResId,
+    )
+
+    Gap(width = MybraryTheme.space.xs)
+  }
+
+  if (isLoading) {
+    CircularProgressIndicator(
+      modifier = Modifier.size(24.dp),
+      color = ButtonDefaults.buttonColors().disabledContentColor,
+      strokeWidth = 3.dp,
+      strokeCap = StrokeCap.Round,
+    )
+
+    Gap(width = MybraryTheme.space.xs)
+  }
+
+  Text(textResId = textResId)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PrimaryButtonPreview(
+  @PreviewParameter(PrimaryButtonPreviewParameterProvider::class) parameter: PrimaryButtonPreviewParameter,
+) {
+  MybraryTheme {
+    PrimaryButton(
+      textResId = android.R.string.ok,
+      onClick = {},
+      modifier = Modifier.fillMaxWidth(),
+      isLoading = parameter.isLoading,
+      isEnabled = parameter.isEnabled,
+    )
+  }
+}
+
+private class PrimaryButtonPreviewParameterProvider :
+  PreviewParameterProvider<PrimaryButtonPreviewParameter> {
+  override val values: Sequence<PrimaryButtonPreviewParameter>
+    get() = sequenceOf(
+      PrimaryButtonPreviewParameter(
+        isLoading = false,
+        isEnabled = true,
+      ),
+      PrimaryButtonPreviewParameter(
+        isLoading = true,
+        isEnabled = true,
+      ),
+      PrimaryButtonPreviewParameter(
+        isLoading = false,
+        isEnabled = false,
+      ),
+    )
+}
+
+private data class PrimaryButtonPreviewParameter(
+  val isLoading: Boolean,
+  val isEnabled: Boolean,
+)

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/SkeletonBox.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/SkeletonBox.kt
@@ -49,7 +49,7 @@ private fun SkeletonBoxPreview() {
     SkeletonBox(
       shape = MybraryTheme.shapes.small,
     ) {
-      Box(modifier = Modifier.size(MybraryTheme.space.xxxl))
+      Box(modifier = Modifier.size(MybraryTheme.space.xxxxl))
     }
   }
 }

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/button/PrimaryButton.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/button/PrimaryButton.kt
@@ -1,9 +1,10 @@
-package app.kaito_dogi.mybrary.core.designsystem.component
+package app.kaito_dogi.mybrary.core.designsystem.component.button
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
@@ -13,6 +14,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import app.kaito_dogi.mybrary.core.designsystem.component.Gap
+import app.kaito_dogi.mybrary.core.designsystem.component.Icon
+import app.kaito_dogi.mybrary.core.designsystem.component.Text
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 
 @Composable
@@ -24,7 +28,7 @@ fun PrimaryButton(
   @StringRes altResId: Int? = null,
   isLoading: Boolean = false,
   isEnabled: Boolean = true,
-) = androidx.compose.material3.Button(
+) = Button(
   onClick = onClick,
   modifier = modifier,
   enabled = isEnabled && !isLoading,

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/button/SecondaryButton.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/button/SecondaryButton.kt
@@ -1,0 +1,97 @@
+package app.kaito_dogi.mybrary.core.designsystem.component.button
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import app.kaito_dogi.mybrary.core.designsystem.component.Gap
+import app.kaito_dogi.mybrary.core.designsystem.component.Icon
+import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+fun SecondaryButton(
+  @StringRes textResId: Int,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  @DrawableRes iconResId: Int? = null,
+  @StringRes altResId: Int? = null,
+  isLoading: Boolean = false,
+  isEnabled: Boolean = true,
+) = OutlinedButton(
+  onClick = onClick,
+  modifier = modifier,
+  enabled = isEnabled && !isLoading,
+) {
+  if (iconResId != null && !isLoading) {
+    Icon(
+      iconResId = iconResId,
+      altResId = altResId,
+    )
+
+    Gap(width = MybraryTheme.space.xs)
+  }
+
+  if (isLoading) {
+    CircularProgressIndicator(
+      modifier = Modifier.size(24.dp),
+      color = ButtonDefaults.buttonColors().disabledContentColor,
+      strokeWidth = 3.dp,
+      strokeCap = StrokeCap.Round,
+    )
+
+    Gap(width = MybraryTheme.space.xs)
+  }
+
+  Text(textResId = textResId)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SecondaryButtonPreview(
+  @PreviewParameter(SecondaryButtonPreviewParameterProvider::class) parameter: SecondaryButtonPreviewParameter,
+) {
+  MybraryTheme {
+    SecondaryButton(
+      textResId = android.R.string.ok,
+      onClick = {},
+      modifier = Modifier.fillMaxWidth(),
+      isLoading = parameter.isLoading,
+      isEnabled = parameter.isEnabled,
+    )
+  }
+}
+
+private class SecondaryButtonPreviewParameterProvider :
+  PreviewParameterProvider<SecondaryButtonPreviewParameter> {
+  override val values: Sequence<SecondaryButtonPreviewParameter>
+    get() = sequenceOf(
+      SecondaryButtonPreviewParameter(
+        isLoading = false,
+        isEnabled = true,
+      ),
+      SecondaryButtonPreviewParameter(
+        isLoading = true,
+        isEnabled = true,
+      ),
+      SecondaryButtonPreviewParameter(
+        isLoading = false,
+        isEnabled = false,
+      ),
+    )
+}
+
+private data class SecondaryButtonPreviewParameter(
+  val isLoading: Boolean,
+  val isEnabled: Boolean,
+)

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/button/SecondaryButton.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/button/SecondaryButton.kt
@@ -35,6 +35,11 @@ fun SecondaryButton(
   onClick = onClick,
   modifier = modifier,
   enabled = isEnabled && !isLoading,
+  colors = ButtonDefaults.outlinedButtonColors().copy(
+    containerColor = MybraryTheme.colorScheme.surface,
+    contentColor = MybraryTheme.colorScheme.onSurfaceVariant,
+    disabledContainerColor = ButtonDefaults.buttonColors().disabledContainerColor,
+  ),
 ) {
   if (iconResId != null && !isLoading) {
     Icon(

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/button/SecondaryButton.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/button/SecondaryButton.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -26,6 +28,7 @@ fun SecondaryButton(
   modifier: Modifier = Modifier,
   @DrawableRes iconResId: Int? = null,
   @StringRes altResId: Int? = null,
+  iconTint: Color? = null,
   isLoading: Boolean = false,
   isEnabled: Boolean = true,
 ) = OutlinedButton(
@@ -37,6 +40,7 @@ fun SecondaryButton(
     Icon(
       iconResId = iconResId,
       altResId = altResId,
+      tint = iconTint ?: LocalContentColor.current,
     )
 
     Gap(width = MybraryTheme.space.xs)

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/theme/Space.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/theme/Space.kt
@@ -14,7 +14,8 @@ internal val mybrarySpace = Space(
   lg = 20.dp,
   xl = 24.dp,
   xxl = 32.dp,
-  xxxl = 64.dp,
+  xxxl = 56.dp,
+  xxxxl = 64.dp,
 )
 
 @Immutable
@@ -28,6 +29,7 @@ data class Space(
   val xl: Dp,
   val xxl: Dp,
   val xxxl: Dp,
+  val xxxxl: Dp,
 )
 
 private val defaultSpace = Space(
@@ -40,6 +42,7 @@ private val defaultSpace = Space(
   xl = Dp.Hairline,
   xxl = Dp.Hairline,
   xxxl = Dp.Hairline,
+  xxxxl = Dp.Hairline,
 )
 
 internal val LocalSpace = staticCompositionLocalOf { defaultSpace }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
   <string name="auth_alt_send_otp">Send One-Time Password</string>
   <string name="auth_alt_sign_up_google">Sign up with Google</string>
   <string name="auth_placeholder_enter_otp">123456</string>
-  <string name="auth_placeholder_enter_your_email_address">Email Address...</string>
+  <string name="auth_placeholder_enter_your_email_address">Email Address…</string>
   <string name="auth_text_already_have_an_account_login">"Already have an account? Login "</string>
   <string name="auth_text_create_an_account">"Create an account "</string>
   <string name="auth_text_enter_otp">Enter One-Time Password</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
   <string name="auth_alt_send_otp">Send One-Time Password</string>
   <string name="auth_alt_sign_up_google">Sign up with Google</string>
   <string name="auth_placeholder_enter_otp">123456</string>
-  <string name="auth_placeholder_enter_your_email_address">Email Address</string>
+  <string name="auth_placeholder_enter_your_email_address">Email Address...</string>
   <string name="auth_text_already_have_an_account_login">"Already have an account? Login "</string>
   <string name="auth_text_create_an_account">"Create an account "</string>
   <string name="auth_text_enter_otp">Enter One-Time Password</string>

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/component/EmailSection.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/component/EmailSection.kt
@@ -20,6 +20,7 @@ import app.kaito_dogi.mybrary.core.ui.R
 @Composable
 internal fun EmailSection(
   email: String,
+  isSendingOtp: Boolean,
   onEmailChange: (String) -> Unit,
   onSendOtpClick: () -> Unit,
   modifier: Modifier = Modifier,
@@ -57,6 +58,7 @@ internal fun EmailSection(
       modifier = Modifier.fillMaxWidth(),
       iconResId = R.drawable.icon_send,
       altResId = R.string.auth_alt_send_otp,
+      isLoading = isSendingOtp,
     )
   }
 }
@@ -67,6 +69,7 @@ private fun EmailSectionPreview() {
   MybraryTheme {
     EmailSection(
       email = "",
+      isSendingOtp = false,
       onEmailChange = {},
       onSendOtpClick = {},
     )

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/component/EmailSection.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/component/EmailSection.kt
@@ -5,16 +5,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
-import app.kaito_dogi.mybrary.core.designsystem.component.Gap
 import app.kaito_dogi.mybrary.core.designsystem.component.Icon
 import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.component.button.PrimaryButton
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.R
 
@@ -52,19 +51,13 @@ internal fun EmailSection(
       singleLine = true,
     )
 
-    Button(
+    PrimaryButton(
+      textResId = R.string.auth_text_send_otp,
       onClick = onSendOtpClick,
       modifier = Modifier.fillMaxWidth(),
-    ) {
-      Icon(
-        iconResId = R.drawable.icon_send,
-        altResId = R.string.auth_alt_send_otp,
-      )
-
-      Gap(width = MybraryTheme.space.xs)
-
-      Text(textResId = R.string.auth_text_send_otp)
-    }
+      iconResId = R.drawable.icon_send,
+      altResId = R.string.auth_alt_send_otp,
+    )
   }
 }
 

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginScreen.kt
@@ -52,6 +52,7 @@ internal fun LoginScreen(
 
       EmailSection(
         email = uiState.email,
+        isSendingOtp = uiState.isOtpSending,
         onEmailChange = onEmailChange,
         onSendOtpClick = onSendOtpClick,
       )
@@ -69,6 +70,7 @@ internal fun LoginScreen(
         iconResId = R.drawable.icon_google,
         altResId = R.string.auth_alt_login_with_google,
         iconTint = Color.Unspecified,
+        isLoading = uiState.isLoggingIn,
       )
 
       Spacer(modifier = Modifier.weight(1f))

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginScreen.kt
@@ -39,7 +39,7 @@ internal fun LoginScreen(
         .padding(
           innerPadding.plus(
             start = MybraryTheme.space.xl,
-            top = MybraryTheme.space.xxxl,
+            top = MybraryTheme.space.xxxxl,
             end = MybraryTheme.space.xl,
             bottom = MybraryTheme.space.xl,
           ),
@@ -48,8 +48,7 @@ internal fun LoginScreen(
     ) {
       LogoSection()
 
-      Gap(height = MybraryTheme.space.xxl)
-      Gap(height = MybraryTheme.space.xl)
+      Gap(height = MybraryTheme.space.xxxl)
 
       EmailSection(
         email = uiState.email,

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,8 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.component.Gap
-import app.kaito_dogi.mybrary.core.designsystem.component.Icon
-import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.component.button.SecondaryButton
 import app.kaito_dogi.mybrary.core.designsystem.ext.plus
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.R
@@ -65,20 +63,14 @@ internal fun LoginScreen(
 
       Gap(height = MybraryTheme.space.xl)
 
-      OutlinedButton(
+      SecondaryButton(
+        textResId = R.string.auth_text_login_with_google,
         onClick = onGoogleLoginClick,
         modifier = Modifier.fillMaxWidth(),
-      ) {
-        Icon(
-          iconResId = R.drawable.icon_google,
-          altResId = R.string.auth_alt_login_with_google,
-          tint = Color.Unspecified,
-        )
-
-        Gap(width = MybraryTheme.space.xs)
-
-        Text(textResId = R.string.auth_text_login_with_google)
-      }
+        iconResId = R.drawable.icon_google,
+        altResId = R.string.auth_alt_login_with_google,
+        iconTint = Color.Unspecified,
+      )
 
       Spacer(modifier = Modifier.weight(1f))
 

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginUiState.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginUiState.kt
@@ -5,13 +5,17 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class LoginUiState(
   val email: String,
+  val isOtpSending: Boolean,
   val isOtpSent: Boolean,
+  val isLoggingIn: Boolean,
   val isLoggedIn: Boolean,
 ) {
   companion object {
     val InitialValue = LoginUiState(
       email = "",
+      isOtpSending = false,
       isOtpSent = false,
+      isLoggingIn = false,
       isLoggedIn = false,
     )
   }

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/login/LoginViewModel.kt
@@ -24,6 +24,7 @@ internal class LoginViewModel @Inject constructor(
   fun onSendOtpClick() {
     viewModelScope.launch {
       try {
+        _uiState.update { it.copy(isOtpSending = true) }
         authRepository.sendOtp(
           email = uiState.value.email,
         )
@@ -31,6 +32,13 @@ internal class LoginViewModel @Inject constructor(
       } catch (e: Exception) {
         // FIXME: 共通のエラーハンドリングを実装する
         println("あああ: ${e.message}")
+      } finally {
+        _uiState.update {
+          it.copy(
+            isOtpSending = false,
+            isOtpSent = false,
+          )
+        }
       }
     }
   }

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpScreen.kt
@@ -52,6 +52,7 @@ internal fun SignUpScreen(
 
       EmailSection(
         email = uiState.email,
+        isSendingOtp = uiState.isOtpSending,
         onEmailChange = onEmailChange,
         onSendOtpClick = onSendOtpClick,
       )
@@ -69,6 +70,7 @@ internal fun SignUpScreen(
         iconResId = R.drawable.icon_google,
         altResId = R.string.auth_alt_sign_up_google,
         iconTint = Color.Unspecified,
+        isLoading = uiState.isSigningUp,
       )
 
       Spacer(modifier = Modifier.weight(1f))

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,8 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.component.Gap
-import app.kaito_dogi.mybrary.core.designsystem.component.Icon
-import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.component.button.SecondaryButton
 import app.kaito_dogi.mybrary.core.designsystem.ext.plus
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.R
@@ -65,20 +63,14 @@ internal fun SignUpScreen(
 
       Gap(height = MybraryTheme.space.xl)
 
-      OutlinedButton(
+      SecondaryButton(
+        textResId = R.string.auth_text_sign_up_with_google,
         onClick = onGoogleSignUpClick,
         modifier = Modifier.fillMaxWidth(),
-      ) {
-        Icon(
-          iconResId = R.drawable.icon_google,
-          altResId = R.string.auth_alt_sign_up_google,
-          tint = Color.Unspecified,
-        )
-
-        Gap(width = MybraryTheme.space.xs)
-
-        Text(textResId = R.string.auth_text_sign_up_with_google)
-      }
+        iconResId = R.drawable.icon_google,
+        altResId = R.string.auth_alt_sign_up_google,
+        iconTint = Color.Unspecified,
+      )
 
       Spacer(modifier = Modifier.weight(1f))
 

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpScreen.kt
@@ -39,7 +39,7 @@ internal fun SignUpScreen(
         .padding(
           innerPadding.plus(
             start = MybraryTheme.space.xl,
-            top = MybraryTheme.space.xxxl,
+            top = MybraryTheme.space.xxxxl,
             end = MybraryTheme.space.xl,
             bottom = MybraryTheme.space.xl,
           ),
@@ -48,8 +48,7 @@ internal fun SignUpScreen(
     ) {
       LogoSection()
 
-      Gap(height = MybraryTheme.space.xxl)
-      Gap(height = MybraryTheme.space.xl)
+      Gap(height = MybraryTheme.space.xxxl)
 
       EmailSection(
         email = uiState.email,

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpUiState.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpUiState.kt
@@ -5,13 +5,17 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class SignUpUiState(
   val email: String,
+  val isOtpSending: Boolean,
   val isOtpSent: Boolean,
+  val isSigningUp: Boolean,
   val isSignedUp: Boolean,
 ) {
   companion object {
     val InitialValue = SignUpUiState(
       email = "",
+      isOtpSending = false,
       isOtpSent = false,
+      isSigningUp = false,
       isSignedUp = false,
     )
   }

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/route/signup/SignUpViewModel.kt
@@ -24,6 +24,7 @@ internal class SignUpViewModel @Inject constructor(
   fun onSendOtpClick() {
     viewModelScope.launch {
       try {
+        _uiState.update { it.copy(isOtpSending = true) }
         authRepository.sendOtp(
           email = uiState.value.email,
         )
@@ -31,6 +32,13 @@ internal class SignUpViewModel @Inject constructor(
       } catch (e: Exception) {
         // FIXME: 共通のエラーハンドリングを実装する
         println("あああ: ${e.message}")
+      } finally {
+        _uiState.update {
+          it.copy(
+            isOtpSending = false,
+            isOtpSent = false,
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
## :thought_balloon: 背景

- Button を押してから通信中にローディングアイコンを表示したい
- Button のスタイル定義を共通化したい

## :sparkles: 実装内容

- PrimaryButton の実装
- SecondaryButton の実装

## :white_check_mark: 動作確認

- [ ] `記入する`

## :art: UI 差分

https://github.com/user-attachments/assets/2287ad01-42e4-49ed-ad56-8f921b645ebd

| Before | After |
|:--:|:--:|
| <img src="" width="300px" /> | <img src="" width="300px" /> |

## :link: 関連リンク

