### PR TITLE
OTP 認証画面の UI を修正

### DIFF
--- a/app/src/main/java/app/kaito_dogi/mybrary/MybraryNavHost.kt
+++ b/app/src/main/java/app/kaito_dogi/mybrary/MybraryNavHost.kt
@@ -69,6 +69,7 @@ internal fun MybraryNavHost(
           }
         }
       },
+      onNavigationIconClick = navController::popBackStack,
     )
   }
 }

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/TopAppBar.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/TopAppBar.kt
@@ -1,7 +1,9 @@
 package app.kaito_dogi.mybrary.core.designsystem.component
 
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -11,9 +13,24 @@ import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 @Composable
 fun TopAppBar(
   @StringRes textResId: Int,
+  @DrawableRes navigationIconResId: Int? = null,
+  @StringRes navigationIconAltResId: Int? = null,
+  onNavigationIconClick: (() -> Unit)? = null,
 ) = androidx.compose.material3.TopAppBar(
   title = {
-    Text(text = stringResource(id = textResId),)
+    Text(text = stringResource(id = textResId))
+  },
+  navigationIcon = {
+    if (navigationIconResId != null && onNavigationIconClick != null) {
+      IconButton(
+        onClick = onNavigationIconClick,
+      ) {
+        Icon(
+          iconResId = navigationIconResId,
+          altResId = navigationIconAltResId,
+        )
+      }
+    }
   },
 )
 

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -54,6 +54,7 @@
   <string name="verify_otp_alt_otp">ワンタイムパスワード</string>
   <string name="verify_otp_back">ワンタイムパスワードの送信に戻る</string>
   <string name="verify_otp_placeholder_enter_otp">123456</string>
+  <string name="verify_otp_text_enter_otp_sent_to">%1$sに送信されたワンタイムパスワードを入力してください</string>
   <string name="verify_otp_text_it_may_take_a_few_minutes">ワンタイムパスワードが届くまで数分かかる場合があります</string>
   <string name="verify_otp_text_login">ログイン</string>
   <string name="verify_otp_text_resend_otp">もう一度ワンタイムパスワードを送信</string>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -57,4 +57,5 @@
   <string name="verify_otp_text_otp_verification">ワンタイムパスワードの認証</string>
   <string name="verify_otp_text_login">ログイン</string>
   <string name="verify_otp_text_sign_up">サインアップ</string>
+  <string name="verify_otp_text_verify_otp">ワンタイムパスワードの認証</string>
 </resources>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -56,6 +56,7 @@
   <string name="verify_otp_placeholder_enter_otp">123456</string>
   <string name="verify_otp_text_it_may_take_a_few_minutes">ワンタイムパスワードが届くまで数分かかる場合があります</string>
   <string name="verify_otp_text_login">ログイン</string>
+  <string name="verify_otp_text_resend_otp">もう一度ワンタイムパスワードを送信</string>
   <string name="verify_otp_text_sign_up">サインアップ</string>
   <string name="verify_otp_text_verify_otp">ワンタイムパスワードの認証</string>
 </resources>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -54,7 +54,7 @@
   <string name="verify_otp_alt_otp">ワンタイムパスワード</string>
   <string name="verify_otp_back">ワンタイムパスワードの送信に戻る</string>
   <string name="verify_otp_placeholder_enter_otp">123456</string>
-  <string name="verify_otp_text_enter_otp">ワンタイムパスワードの入力</string>
+  <string name="verify_otp_text_otp_verification">ワンタイムパスワードの認証</string>
   <string name="verify_otp_text_login">ログイン</string>
   <string name="verify_otp_text_sign_up">サインアップ</string>
 </resources>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="my_book_detail_alt_add_my_book_to_favorites">MyBook をお気に入りに追加する</string>
-  <string name="my_book_detail_alt_archive_my_book">MyBook をアーカイブする</string>
+  <string name="my_book_detail_alt_add_my_book_to_favorites">本をお気に入りに追加する</string>
+  <string name="my_book_detail_alt_archive_my_book">本をアーカイブする</string>
   <string name="my_book_detail_alt_background_image">背景画像</string>
   <string name="my_book_detail_alt_create_a_memo">メモを作成する</string>
-  <string name="my_book_detail_alt_make_my_book_private">MyBook を非公開にする</string>
-  <string name="my_book_detail_alt_make_my_book_public">MyBook を公開する</string>
-  <string name="my_book_detail_alt_remove_my_book_from_favorites">MyBook をお気に入りから削除する</string>
+  <string name="my_book_detail_alt_make_my_book_private">本を非公開にする</string>
+  <string name="my_book_detail_alt_make_my_book_public">本を公開する</string>
+  <string name="my_book_detail_alt_remove_my_book_from_favorites">本をお気に入りから削除する</string>
   <string name="my_book_detail_alt_save_a_memo">メモを保存する</string>
-  <string name="my_book_detail_message_my_book_added_to_your_favorites">MyBook をお気に入りに追加しました</string>
-  <string name="my_book_detail_message_my_book_archived">MyBook をアーカイブしました</string>
-  <string name="my_book_detail_message_my_book_is_now_private">MyBook を公開しました</string>
-  <string name="my_book_detail_message_my_book_is_now_public">MyBook を非公開にしました</string>
-  <string name="my_book_detail_message_my_book_removed_from_your_favorites">MyBook をお気に入りから削除しました</string>
+  <string name="my_book_detail_message_my_book_added_to_your_favorites">お気に入りに追加しました</string>
+  <string name="my_book_detail_message_my_book_archived">アーカイブしました</string>
+  <string name="my_book_detail_message_my_book_is_now_private">公開しました</string>
+  <string name="my_book_detail_message_my_book_is_now_public">非公開にしました</string>
+  <string name="my_book_detail_message_my_book_removed_from_your_favorites">お気に入りから削除しました</string>
   <string name="my_book_detail_message_memo_created">メモを作成しました</string>
   <string name="my_book_detail_message_memo_edited">メモを編集しました</string>
   <string name="my_book_detail_placeholder_end_page">終了ページ</string>
@@ -26,9 +26,9 @@
   <string name="my_book_detail_text_pp">pp.%1$d~%2$d</string>
   <string name="my_book_list_alt_search_for_books">本を検索する</string>
   <string name="my_book_list_text_a">あ</string>
-  <string name="my_book_list_text_all_my_books">すべて</string>
-  <string name="my_book_list_text_favorite_my_books">お気に入り</string>
-  <string name="my_book_list_text_other_my_books">その他</string>
+  <string name="my_book_list_text_all_my_books">すべての本</string>
+  <string name="my_book_list_text_favorite_my_books">お気に入りの本</string>
+  <string name="my_book_list_text_other_my_books">その他の本</string>
   <string name="search_book_alt_scan_book_barcode">バーコードを読み取る</string>
   <string name="search_book_alt_search_for_books">本を検索する</string>
   <string name="search_book_placeholder_enter_search_keywords">検索ワードを入力…</string>
@@ -36,7 +36,7 @@
   <string name="search_book_text_add">追加する</string>
   <string name="search_book_text_a_a">あ\nあ</string>
   <string name="search_book_text_cancel">追加しない</string>
-  <string name="search_book_text_would_you_like_to_add_to_mybrary">Mybraryに本を追加しますか？</string>
+  <string name="search_book_text_would_you_like_to_add_to_mybrary">Mybrary に本を追加しますか？</string>
   <string name="send_otp_alt_email_address">メールアドレス</string>
   <string name="send_otp_alt_login_with_google">Google アカウントでログイン</string>
   <string name="send_otp_alt_send_otp">ワンタイムパスワードを送信</string>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -52,6 +52,7 @@
   <string name="send_otp_text_sign_up_with_google">Google アカウントで始める</string>
   <string name="ui_alt_book_cover">本の表紙</string>
   <string name="verify_otp_alt_otp">ワンタイムパスワード</string>
+  <string name="verify_otp_back">ワンタイムパスワードの送信に戻る</string>
   <string name="verify_otp_placeholder_enter_otp">123456</string>
   <string name="verify_otp_text_enter_otp">ワンタイムパスワードの入力</string>
   <string name="verify_otp_text_login">ログイン</string>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -54,7 +54,7 @@
   <string name="verify_otp_alt_otp">ワンタイムパスワード</string>
   <string name="verify_otp_back">ワンタイムパスワードの送信に戻る</string>
   <string name="verify_otp_placeholder_enter_otp">123456</string>
-  <string name="verify_otp_text_otp_verification">ワンタイムパスワードの認証</string>
+  <string name="verify_otp_text_it_may_take_a_few_minutes">ワンタイムパスワードが届くまで数分かかる場合があります</string>
   <string name="verify_otp_text_login">ログイン</string>
   <string name="verify_otp_text_sign_up">サインアップ</string>
   <string name="verify_otp_text_verify_otp">ワンタイムパスワードの認証</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
   <string name="verify_otp_alt_otp">One-Time Password</string>
   <string name="verify_otp_back">Back to send One-Time Password</string>
   <string name="verify_otp_placeholder_enter_otp">123456</string>
+  <string name="verify_otp_text_enter_otp_sent_to">Enter the One-Time Password sent to %1$s</string>
   <string name="verify_otp_text_it_may_take_a_few_minutes">It may take a few minutes to receive the one-time password.</string>
   <string name="verify_otp_text_login">Login</string>
   <string name="verify_otp_text_resend_otp">Resend One-Time Password</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
   <string name="send_otp_text_sign_up_with_google">Sign up with Google</string>
   <string name="ui_alt_book_cover">Book cover</string>
   <string name="verify_otp_alt_otp">One-Time Password</string>
+  <string name="verify_otp_back">Back to send One-Time Password</string>
   <string name="verify_otp_placeholder_enter_otp">123456</string>
   <string name="verify_otp_text_enter_otp">Enter One-Time Password</string>
   <string name="verify_otp_text_login">Login</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -57,4 +57,5 @@
   <string name="verify_otp_text_otp_verification">One-Time Password Verification</string>
   <string name="verify_otp_text_login">Login</string>
   <string name="verify_otp_text_sign_up">Sign up</string>
+  <string name="verify_otp_text_verify_otp">Verify One-Time Password</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
   <string name="verify_otp_placeholder_enter_otp">123456</string>
   <string name="verify_otp_text_it_may_take_a_few_minutes">It may take a few minutes to receive the one-time password.</string>
   <string name="verify_otp_text_login">Login</string>
+  <string name="verify_otp_text_resend_otp">Resend One-Time Password</string>
   <string name="verify_otp_text_sign_up">Sign up</string>
   <string name="verify_otp_text_verify_otp">Verify One-Time Password</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
   <string name="verify_otp_alt_otp">One-Time Password</string>
   <string name="verify_otp_back">Back to send One-Time Password</string>
   <string name="verify_otp_placeholder_enter_otp">123456</string>
-  <string name="verify_otp_text_enter_otp">Enter One-Time Password</string>
+  <string name="verify_otp_text_otp_verification">One-Time Password Verification</string>
   <string name="verify_otp_text_login">Login</string>
   <string name="verify_otp_text_sign_up">Sign up</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
   <string name="verify_otp_alt_otp">One-Time Password</string>
   <string name="verify_otp_back">Back to send One-Time Password</string>
   <string name="verify_otp_placeholder_enter_otp">123456</string>
-  <string name="verify_otp_text_otp_verification">One-Time Password Verification</string>
+  <string name="verify_otp_text_it_may_take_a_few_minutes">It may take a few minutes to receive the one-time password.</string>
   <string name="verify_otp_text_login">Login</string>
   <string name="verify_otp_text_sign_up">Sign up</string>
   <string name="verify_otp_text_verify_otp">Verify One-Time Password</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="my_book_detail_alt_add_my_book_to_favorites">Add MyBook to favorites</string>
-  <string name="my_book_detail_alt_archive_my_book">Archive MyBook</string>
+  <string name="my_book_detail_alt_add_my_book_to_favorites">Add your book to favorites</string>
+  <string name="my_book_detail_alt_archive_my_book">Archive your book</string>
   <string name="my_book_detail_alt_background_image">Background image</string>
   <string name="my_book_detail_alt_create_a_memo">Create a note</string>
-  <string name="my_book_detail_alt_make_my_book_private">Make MyBook private</string>
-  <string name="my_book_detail_alt_make_my_book_public">Make MyBook public</string>
-  <string name="my_book_detail_alt_remove_my_book_from_favorites">Remove MyBook from favorites</string>
+  <string name="my_book_detail_alt_make_my_book_private">Make your book private</string>
+  <string name="my_book_detail_alt_make_my_book_public">Make your book public</string>
+  <string name="my_book_detail_alt_remove_my_book_from_favorites">Remove your book from favorites</string>
   <string name="my_book_detail_alt_save_a_memo">Save a note</string>
-  <string name="my_book_detail_message_my_book_added_to_your_favorites">MyBook added to your favorites</string>
-  <string name="my_book_detail_message_my_book_archived">MyBook archived</string>
-  <string name="my_book_detail_message_my_book_is_now_private">MyBook is now private</string>
-  <string name="my_book_detail_message_my_book_is_now_public">MyBook is now public</string>
-  <string name="my_book_detail_message_my_book_removed_from_your_favorites">MyBook removed from your favorites</string>
+  <string name="my_book_detail_message_my_book_added_to_your_favorites">Your book added to favorites</string>
+  <string name="my_book_detail_message_my_book_archived">Your book archived</string>
+  <string name="my_book_detail_message_my_book_is_now_private">Your book is now private</string>
+  <string name="my_book_detail_message_my_book_is_now_public">Your book is now public</string>
+  <string name="my_book_detail_message_my_book_removed_from_your_favorites">Your book removed from favorites</string>
   <string name="my_book_detail_message_memo_created">Note created</string>
   <string name="my_book_detail_message_memo_edited">Note edited</string>
   <string name="my_book_detail_placeholder_end_page">End Page</string>
@@ -26,9 +26,9 @@
   <string name="my_book_detail_text_pp">pp.%1$d~%2$d</string>
   <string name="my_book_list_alt_search_for_books">Search for books</string>
   <string name="my_book_list_text_a">A</string>
-  <string name="my_book_list_text_all_my_books">All</string>
-  <string name="my_book_list_text_favorite_my_books">Favorites</string>
-  <string name="my_book_list_text_other_my_books">Others</string>
+  <string name="my_book_list_text_all_my_books">All Books</string>
+  <string name="my_book_list_text_favorite_my_books">Favorite Books</string>
+  <string name="my_book_list_text_other_my_books">Other Books</string>
   <string name="search_book_alt_scan_book_barcode">Scan book barcode</string>
   <string name="search_book_alt_search_for_books">Search for books</string>
   <string name="search_book_placeholder_enter_search_keywords">Search…</string>

--- a/feature/send-otp/src/main/java/app/kaito_dogi/mybrary/feature/sendotp/SendOtpScreen.kt
+++ b/feature/send-otp/src/main/java/app/kaito_dogi/mybrary/feature/sendotp/SendOtpScreen.kt
@@ -54,12 +54,10 @@ internal fun SendOtpScreen(
             end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY),
           ),
         )
-        .imePadding(),
+        .padding(innerPadding),
     ) {
       LogoSection(
-        modifier = Modifier.padding(
-          top = innerPadding.calculateTopPadding() + MybraryTheme.spaces.xxxl,
-        ),
+        modifier = Modifier.padding(top = MybraryTheme.spaces.xxxl),
       )
 
       Gap(height = MybraryTheme.spaces.xxxl)
@@ -69,7 +67,9 @@ internal fun SendOtpScreen(
         isSendingOtp = uiState.isOtpSending,
         onEmailChange = onEmailChange,
         onSendOtpClick = onSendOtpClick,
-        modifier = Modifier.padding(horizontal = MybraryTheme.spaces.xl),
+        modifier = Modifier
+          .padding(horizontal = MybraryTheme.spaces.xl)
+          .imePadding(),
       )
 
       Gap(height = MybraryTheme.spaces.xl)
@@ -107,9 +107,7 @@ internal fun SendOtpScreen(
         currentPage = pagerState.currentPage,
         modifier = Modifier
           .fillMaxWidth()
-          .padding(
-            bottom = innerPadding.calculateBottomPadding() + MybraryTheme.spaces.xl,
-          ),
+          .padding(bottom = MybraryTheme.spaces.xl),
       )
     }
   }

--- a/feature/send-otp/src/main/java/app/kaito_dogi/mybrary/feature/sendotp/page/LoginPage.kt
+++ b/feature/send-otp/src/main/java/app/kaito_dogi/mybrary/feature/sendotp/page/LoginPage.kt
@@ -36,7 +36,10 @@ internal fun LoginPage(
 
     Spacer(modifier = Modifier.weight(1f))
 
-    SignUpSection(onClick = onSignUpClick)
+    SignUpSection(
+      onClick = onSignUpClick,
+      modifier = Modifier.fillMaxWidth(),
+    )
   }
 }
 

--- a/feature/send-otp/src/main/java/app/kaito_dogi/mybrary/feature/sendotp/page/SignUpPage.kt
+++ b/feature/send-otp/src/main/java/app/kaito_dogi/mybrary/feature/sendotp/page/SignUpPage.kt
@@ -36,7 +36,10 @@ internal fun SignUpPage(
 
     Spacer(modifier = Modifier.weight(1f))
 
-    LoginSection(onClick = onLoginClick)
+    LoginSection(
+      onClick = onLoginClick,
+      modifier = Modifier.fillMaxWidth(),
+    )
   }
 }
 

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpNavigation.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpNavigation.kt
@@ -12,12 +12,14 @@ internal val verifyOtpTypeMap = mapOf(
 
 fun NavGraphBuilder.verifyOtpScreen(
   onVerifyOtpComplete: () -> Unit,
+  onNavigationIconClick: () -> Unit,
 ) {
   composable<MybraryRoute.VerifyOtp>(
     typeMap = verifyOtpTypeMap,
   ) {
     VerifyOtpScreenContainer(
       onVerifyOtpComplete = onVerifyOtpComplete,
+      onNavigationIconClick = onNavigationIconClick,
     )
   }
 }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -1,6 +1,5 @@
 package app.kaito_dogi.mybrary.feature.verifyotp
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,8 +11,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.component.Gap
 import app.kaito_dogi.mybrary.core.designsystem.component.PrimaryButton
 import app.kaito_dogi.mybrary.core.designsystem.component.TertiaryButton
+import app.kaito_dogi.mybrary.core.designsystem.component.Text
 import app.kaito_dogi.mybrary.core.designsystem.component.TextField
 import app.kaito_dogi.mybrary.core.designsystem.component.TopAppBar
 import app.kaito_dogi.mybrary.core.designsystem.ext.plus
@@ -58,6 +59,8 @@ internal fun VerifyOtpScreen(
         singleLine = true,
       )
 
+      Gap(height = MybraryTheme.spaces.md)
+
       PrimaryButton(
         textResId = when (uiState.page) {
           MybraryRoute.VerifyOtp.Page.Login -> R.string.verify_otp_text_login
@@ -67,7 +70,13 @@ internal fun VerifyOtpScreen(
         modifier = Modifier.fillMaxWidth(),
         isLoading = uiState.isOtpVerifying,
       )
+
+      Gap(height = MybraryTheme.spaces.xl)
+
       Text(text = stringResource(id = R.string.verify_otp_text_it_may_take_a_few_minutes))
+
+      Gap(height = MybraryTheme.spaces.md)
+
       TertiaryButton(
         textResId = R.string.verify_otp_text_resend_otp,
         onClick = onResendOtpClick,

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -1,6 +1,7 @@
 package app.kaito_dogi.mybrary.feature.verifyotp
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -79,7 +80,7 @@ internal fun VerifyOtpScreen(
         isLoading = uiState.isOtpVerifying,
       )
 
-      Gap(height = MybraryTheme.spaces.xl)
+      Spacer(modifier = Modifier.weight(1f))
 
       Text(text = stringResource(id = R.string.verify_otp_text_it_may_take_a_few_minutes))
 
@@ -88,7 +89,9 @@ internal fun VerifyOtpScreen(
       TertiaryButton(
         textResId = R.string.verify_otp_text_resend_otp,
         onClick = onResendOtpClick,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(bottom = MybraryTheme.spaces.xl),
       )
     }
   }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -76,7 +77,9 @@ internal fun VerifyOtpScreen(
           MybraryRoute.VerifyOtp.Page.SignUp -> R.string.verify_otp_text_sign_up
         },
         onClick = onVerifyOtpClick,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+          .fillMaxWidth()
+          .imePadding(),
         isLoading = uiState.isOtpVerifying,
       )
 

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -95,6 +95,7 @@ internal fun VerifyOtpScreen(
         modifier = Modifier
           .fillMaxWidth()
           .padding(bottom = MybraryTheme.spaces.xl),
+        isLoading = uiState.isOtpResending,
       )
     }
   }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -29,7 +29,7 @@ internal fun VerifyOtpScreen(
   Scaffold(
     topBar = {
       TopAppBar(
-        textResId = R.string.verify_otp_text_enter_otp,
+        textResId = R.string.verify_otp_text_otp_verification,
         navigationIconResId = R.drawable.icon_arrow_back,
         navigationIconAltResId = R.string.verify_otp_back,
         onNavigationIconClick = onNavigationIconClick,

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.component.PrimaryButton
+import app.kaito_dogi.mybrary.core.designsystem.component.TertiaryButton
 import app.kaito_dogi.mybrary.core.designsystem.component.TextField
 import app.kaito_dogi.mybrary.core.designsystem.component.TopAppBar
 import app.kaito_dogi.mybrary.core.designsystem.ext.plus
@@ -25,6 +27,7 @@ internal fun VerifyOtpScreen(
   onNavigationIconClick: () -> Unit,
   onOtpChange: (String) -> Unit,
   onVerifyOtpClick: () -> Unit,
+  onResendOtpClick: () -> Unit,
 ) {
   Scaffold(
     topBar = {
@@ -65,6 +68,11 @@ internal fun VerifyOtpScreen(
         isLoading = uiState.isOtpVerifying,
       )
       Text(text = stringResource(id = R.string.verify_otp_text_it_may_take_a_few_minutes))
+      TertiaryButton(
+        textResId = R.string.verify_otp_text_resend_otp,
+        onClick = onResendOtpClick,
+        modifier = Modifier.fillMaxWidth(),
+      )
     }
   }
 }
@@ -80,6 +88,7 @@ private fun VerifyOtpScreenPreview() {
       onNavigationIconClick = {},
       onOtpChange = {},
       onVerifyOtpClick = {},
+      onResendOtpClick = {},
     )
   }
 }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -44,8 +44,16 @@ internal fun VerifyOtpScreen(
       modifier = Modifier
         .fillMaxSize()
         .padding(innerPadding.plus(horizontal = MybraryTheme.spaces.md)),
-      verticalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.md),
     ) {
+      Text(
+        text = stringResource(
+          id = R.string.verify_otp_text_enter_otp_sent_to,
+          uiState.maskedEmail,
+        ),
+      )
+
+      Gap(height = MybraryTheme.spaces.xl)
+
       TextField(
         value = uiState.otp,
         onValueChange = onOtpChange,
@@ -93,6 +101,7 @@ private fun VerifyOtpScreenPreview() {
     VerifyOtpScreen(
       uiState = VerifyOtpUiState.createInitialValue(
         page = MybraryRoute.VerifyOtp.Page.Login,
+        email = "kendobu0405@gmail.com",
       ),
       onNavigationIconClick = {},
       onOtpChange = {},

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -64,6 +64,7 @@ internal fun VerifyOtpScreen(
         modifier = Modifier.fillMaxWidth(),
         isLoading = uiState.isOtpVerifying,
       )
+      Text(text = stringResource(id = R.string.verify_otp_text_it_may_take_a_few_minutes))
     }
   }
 }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -22,11 +22,19 @@ import app.kaito_dogi.mybrary.core.ui.navigation.MybraryRoute
 @Composable
 internal fun VerifyOtpScreen(
   uiState: VerifyOtpUiState,
+  onNavigationIconClick: () -> Unit,
   onOtpChange: (String) -> Unit,
   onVerifyOtpClick: () -> Unit,
 ) {
   Scaffold(
-    topBar = { TopAppBar(textResId = R.string.verify_otp_text_enter_otp) },
+    topBar = {
+      TopAppBar(
+        textResId = R.string.verify_otp_text_enter_otp,
+        navigationIconResId = R.drawable.icon_arrow_back,
+        navigationIconAltResId = R.string.verify_otp_back,
+        onNavigationIconClick = onNavigationIconClick,
+      )
+    },
   ) { innerPadding ->
     Column(
       modifier = Modifier
@@ -68,6 +76,7 @@ private fun VerifyOtpScreenPreview() {
       uiState = VerifyOtpUiState.createInitialValue(
         page = MybraryRoute.VerifyOtp.Page.Login,
       ),
+      onNavigationIconClick = {},
       onOtpChange = {},
       onVerifyOtpClick = {},
     )

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -29,7 +29,7 @@ internal fun VerifyOtpScreen(
   Scaffold(
     topBar = {
       TopAppBar(
-        textResId = R.string.verify_otp_text_otp_verification,
+        textResId = R.string.verify_otp_text_verify_otp,
         navigationIconResId = R.drawable.icon_arrow_back,
         navigationIconAltResId = R.string.verify_otp_back,
         onNavigationIconClick = onNavigationIconClick,

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreenContainer.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreenContainer.kt
@@ -26,5 +26,6 @@ internal fun VerifyOtpScreenContainer(
     onNavigationIconClick = onNavigationIconClick,
     onOtpChange = viewModel::onOtpChange,
     onVerifyOtpClick = viewModel::onVerifyOtpClick,
+    onResendOtpClick = viewModel::onResendOtpClick,
   )
 }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreenContainer.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreenContainer.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 @Composable
 internal fun VerifyOtpScreenContainer(
   onVerifyOtpComplete: () -> Unit,
+  onNavigationIconClick: () -> Unit,
   viewModel: VerifyOtpViewModel = hiltViewModel(),
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -22,6 +23,7 @@ internal fun VerifyOtpScreenContainer(
 
   VerifyOtpScreen(
     uiState = uiState,
+    onNavigationIconClick = onNavigationIconClick,
     onOtpChange = viewModel::onOtpChange,
     onVerifyOtpClick = viewModel::onVerifyOtpClick,
   )

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpUiState.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpUiState.kt
@@ -11,6 +11,8 @@ internal data class VerifyOtpUiState(
   val otp: String,
   val isOtpVerifying: Boolean,
   val isOtpVerified: Boolean,
+  val isOtpResending: Boolean,
+  val isOtpResent: Boolean,
 ) {
   companion object {
     fun createInitialValue(
@@ -22,6 +24,8 @@ internal data class VerifyOtpUiState(
       otp = "",
       isOtpVerifying = false,
       isOtpVerified = false,
+      isOtpResending = false,
+      isOtpResent = false,
     )
   }
 

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpUiState.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpUiState.kt
@@ -3,8 +3,10 @@ package app.kaito_dogi.mybrary.feature.verifyotp
 import androidx.compose.runtime.Immutable
 import app.kaito_dogi.mybrary.core.ui.navigation.MybraryRoute
 
+// FIXME: UiState と ViewModelState を分けてみる
 @Immutable
 internal data class VerifyOtpUiState(
+  val email: String,
   val page: MybraryRoute.VerifyOtp.Page,
   val otp: String,
   val isOtpVerifying: Boolean,
@@ -12,12 +14,32 @@ internal data class VerifyOtpUiState(
 ) {
   companion object {
     fun createInitialValue(
+      email: String,
       page: MybraryRoute.VerifyOtp.Page,
     ) = VerifyOtpUiState(
+      email = email,
       page = page,
       otp = "",
       isOtpVerifying = false,
       isOtpVerified = false,
     )
+  }
+
+  val maskedEmail = email.let {
+    val atIndex = email.indexOf(string = "@")
+
+    // "@" が1文字目の場合はマスクしない
+    if (atIndex <= 1) return@let email
+
+    val userName = email.substring(0, atIndex)
+    val domainName = email.substring(atIndex)
+
+    val maskedUserName = when (userName.length) {
+      1 -> userName
+      2 -> "${userName[0]}*"
+      else -> "${userName[0]}${"*".repeat(userName.length - 2)}${userName[userName.length - 1]}"
+    }
+
+    return@let maskedUserName + domainName
   }
 }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
@@ -49,7 +49,15 @@ internal class VerifyOtpViewModel @Inject constructor(
   }
 
   fun onResendOtpClick() {
-    // TODO: 実装する
+    viewModelScope.launchSafe {
+      _uiState.update { it.copy(isOtpResending = true) }
+      otpRepository.sendOtp(
+        email = uiState.value.email,
+      )
+      _uiState.update { it.copy(isOtpResent = true) }
+    }.invokeOnCompletion {
+      _uiState.update { it.copy(isOtpResending = false) }
+    }
   }
 
   fun onUiEventConsume() {

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
@@ -23,6 +23,7 @@ internal class VerifyOtpViewModel @Inject constructor(
 
   private val _uiState = MutableStateFlow(
     VerifyOtpUiState.createInitialValue(
+      email = navArg.email,
       page = navArg.page,
     ),
   )
@@ -37,7 +38,7 @@ internal class VerifyOtpViewModel @Inject constructor(
       _uiState.update { it.copy(isOtpVerifying = true) }
 
       otpRepository.verifyOtp(
-        email = navArg.email,
+        email = uiState.value.email,
         otp = uiState.value.otp,
       )
 

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
@@ -47,6 +47,10 @@ internal class VerifyOtpViewModel @Inject constructor(
     }
   }
 
+  fun onResendOtpClick() {
+    // TODO: 実装する
+  }
+
   fun onUiEventConsume() {
     _uiState.update { it.copy(isOtpVerified = false) }
   }


### PR DESCRIPTION
## :thought_balloon: 背景

- OTP 認証画面をより分かりやすくしたい

## :sparkles: 実装内容

- どのメアドにメールを送信したかを明示
- OTP の再送ボタンを表示

## :white_check_mark: 動作確認

- [ ] `記入する`

## :art: UI 差分

| Before | After |
|:--:|:--:|
| <img src="" width="300px" /> | <img src="https://github.com/user-attachments/assets/f596f14c-978f-40bc-8ee5-45cea24293ff" width="300px" /> |

## :link: 関連リンク

