### PR TITLE
設定リスト画面の実装

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -44,14 +44,17 @@ jobs:
           bundle install
       - name: Run Lint
         env:
+          PRIVACY_POLICY_URL: ${{ vars.PRIVACY_POLICY_URL }}
           RAKUTEN_AFFILIATE_ID_DEV: ${{ secrets.RAKUTEN_AFFILIATE_ID_DEV }}
           RAKUTEN_AFFILIATE_ID_PROD: ${{ secrets.RAKUTEN_AFFILIATE_ID_PROD }}
           RAKUTEN_APPLICATION_ID_DEV: ${{ secrets.RAKUTEN_APPLICATION_ID_DEV }}
           RAKUTEN_APPLICATION_ID_PROD: ${{ secrets.RAKUTEN_APPLICATION_ID_PROD }}
+          RAKUTEN_DEVELOPERS_URL: ${{ vars.RAKUTEN_DEVELOPERS_URL }}
           SUPABASE_KEY_DEV: ${{ secrets.SUPABASE_KEY_DEV }}
           SUPABASE_KEY_PROD: ${{ secrets.SUPABASE_KEY_PROD }}
           SUPABASE_URL_DEV: ${{ secrets.SUPABASE_URL_DEV }}
           SUPABASE_URL_PROD: ${{ secrets.SUPABASE_URL_PROD }}
+          TERMS_OF_USE: ${{ vars.TERMS_OF_USE }}
         run: |
           ./gradlew lintDebug --no-daemon
       - name: Copy Lint Result

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -44,14 +44,17 @@ jobs:
           bundle install
       - name: Run Test
         env:
+          PRIVACY_POLICY_URL: ${{ vars.PRIVACY_POLICY_URL }}
           RAKUTEN_AFFILIATE_ID_DEV: ${{ secrets.RAKUTEN_AFFILIATE_ID_DEV }}
           RAKUTEN_AFFILIATE_ID_PROD: ${{ secrets.RAKUTEN_AFFILIATE_ID_PROD }}
           RAKUTEN_APPLICATION_ID_DEV: ${{ secrets.RAKUTEN_APPLICATION_ID_DEV }}
           RAKUTEN_APPLICATION_ID_PROD: ${{ secrets.RAKUTEN_APPLICATION_ID_PROD }}
+          RAKUTEN_DEVELOPERS_URL: ${{ vars.RAKUTEN_DEVELOPERS_URL }}
           SUPABASE_KEY_DEV: ${{ secrets.SUPABASE_KEY_DEV }}
           SUPABASE_KEY_PROD: ${{ secrets.SUPABASE_KEY_PROD }}
           SUPABASE_URL_DEV: ${{ secrets.SUPABASE_URL_DEV }}
           SUPABASE_URL_PROD: ${{ secrets.SUPABASE_URL_PROD }}
+          TERMS_OF_USE: ${{ vars.TERMS_OF_USE }}
         run: ./gradlew test --stacktrace
       - name: Copy Test Result
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ private fun VariantDimension.buildConfigStringField(
   value = value?.let { "\"$it\"" } ?: initialValue,
 )
 
-private fun getEnvOrEmpty(name: String) = System.getenv(name) ?: ""
+private fun getEnvOrEmpty(name: String) = "\"${System.getenv(name)}\""
 
 plugins {
   alias(libs.plugins.androidApplication)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,11 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
     buildConfigStringField(
+      name = "PRIVACY_POLICY_URL",
+      value = properties.getProperty("privacyPolicyUrl"),
+      initialValue = getEnvOrEmpty(name = "RAKUTEN_AFFILIATE_ID_DEV"),
+    )
+    buildConfigStringField(
       name = "RAKUTEN_AFFILIATE_ID",
       value = properties.getProperty("rakuten.affiliateId.dev"),
       initialValue = getEnvOrEmpty(name = "RAKUTEN_AFFILIATE_ID_DEV"),
@@ -50,6 +55,11 @@ android {
       initialValue = getEnvOrEmpty(name = "RAKUTEN_APPLICATION_ID_DEV"),
     )
     buildConfigStringField(
+      name = "RAKUTEN_DEVELOPERS_URL",
+      value = properties.getProperty("rakuten.developersUrl"),
+      initialValue = getEnvOrEmpty(name = "RAKUTEN_DEVELOPERS_URL"),
+    )
+    buildConfigStringField(
       name = "SUPABASE_KEY",
       value = properties.getProperty("supabase.key.dev"),
       initialValue = getEnvOrEmpty(name = "SUPABASE_KEY_DEV"),
@@ -58,6 +68,11 @@ android {
       name = "SUPABASE_URL",
       value = properties.getProperty("supabase.url.dev"),
       initialValue = getEnvOrEmpty(name = "SUPABASE_URL_DEV"),
+    )
+    buildConfigStringField(
+      name = "TERMS_OF_USE",
+      value = properties.getProperty("termsOfUseUrl"),
+      initialValue = getEnvOrEmpty(name = "TERMS_OF_USE"),
     )
     buildConfigStringField(
       name = "VERSION_NAME",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,23 @@
+import com.android.build.api.dsl.VariantDimension
 import java.util.Properties
 
-val properties = Properties()
-val secretsProperties = rootProject.file("./secrets.properties")
+private val properties = Properties()
+private val secretsProperties = rootProject.file("./secrets.properties")
 if (secretsProperties.exists()) {
   properties.load(secretsProperties.inputStream())
 }
+
+private fun VariantDimension.buildConfigStringField(
+  name: String,
+  value: String?,
+  initialValue: String,
+) = this.buildConfigField(
+  type = "String",
+  name = name,
+  value = value?.let { "\"$it\"" } ?: initialValue,
+)
+
+private fun getEnvOrEmpty(name: String) = System.getenv(name) ?: ""
 
 plugins {
   alias(libs.plugins.androidApplication)
@@ -26,27 +39,30 @@ android {
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-    buildConfigField(
-      type = "String",
+    buildConfigStringField(
       name = "RAKUTEN_AFFILIATE_ID",
-      value = properties.getProperty("rakuten.affiliateId.dev")
-        ?: System.getenv("RAKUTEN_AFFILIATE_ID_DEV"),
+      value = properties.getProperty("rakuten.affiliateId.dev"),
+      initialValue = getEnvOrEmpty(name = "RAKUTEN_AFFILIATE_ID_DEV"),
     )
-    buildConfigField(
-      type = "String",
+    buildConfigStringField(
       name = "RAKUTEN_APPLICATION_ID",
-      value = properties.getProperty("rakuten.applicationId.dev")
-        ?: System.getenv("RAKUTEN_APPLICATION_ID_DEV"),
+      value = properties.getProperty("rakuten.applicationId.dev"),
+      initialValue = getEnvOrEmpty(name = "RAKUTEN_APPLICATION_ID_DEV"),
     )
-    buildConfigField(
-      type = "String",
+    buildConfigStringField(
       name = "SUPABASE_KEY",
-      value = properties.getProperty("supabase.key.dev") ?: System.getenv("SUPABASE_KEY_DEV"),
+      value = properties.getProperty("supabase.key.dev"),
+      initialValue = getEnvOrEmpty(name = "SUPABASE_KEY_DEV"),
     )
-    buildConfigField(
-      type = "String",
+    buildConfigStringField(
       name = "SUPABASE_URL",
-      value = properties.getProperty("supabase.url.dev") ?: System.getenv("SUPABASE_URL_DEV"),
+      value = properties.getProperty("supabase.url.dev"),
+      initialValue = getEnvOrEmpty(name = "SUPABASE_URL_DEV"),
+    )
+    buildConfigStringField(
+      name = "VERSION_NAME",
+      value = versionName,
+      initialValue = "",
     )
   }
 
@@ -70,27 +86,25 @@ android {
     create("prod") {
       dimension = "env"
 
-      buildConfigField(
-        type = "String",
+      buildConfigStringField(
         name = "RAKUTEN_AFFILIATE_ID",
-        value = properties.getProperty("rakuten.affiliateId.prod")
-          ?: System.getenv("RAKUTEN_AFFILIATE_ID_PROD"),
+        value = properties.getProperty("rakuten.affiliateId.prod"),
+        initialValue = getEnvOrEmpty(name = "RAKUTEN_AFFILIATE_ID_PROD"),
       )
-      buildConfigField(
-        type = "String",
+      buildConfigStringField(
         name = "RAKUTEN_APPLICATION_ID",
-        value = properties.getProperty("rakuten.applicationId.prod")
-          ?: System.getenv("RAKUTEN_APPLICATION_ID_PROD"),
+        value = properties.getProperty("rakuten.applicationId.prod"),
+        initialValue = getEnvOrEmpty(name = "RAKUTEN_APPLICATION_ID_PROD"),
       )
-      buildConfigField(
-        type = "String",
+      buildConfigStringField(
         name = "SUPABASE_KEY",
-        value = properties.getProperty("supabase.key.prod") ?: System.getenv("SUPABASE_KEY_PROD"),
+        value = properties.getProperty("supabase.key.prod"),
+        initialValue = getEnvOrEmpty(name = "SUPABASE_KEY_PROD"),
       )
-      buildConfigField(
-        type = "String",
+      buildConfigStringField(
         name = "SUPABASE_URL",
-        value = properties.getProperty("supabase.url.prod") ?: System.getenv("SUPABASE_URL_PROD"),
+        value = properties.getProperty("supabase.url.prod"),
+        initialValue = getEnvOrEmpty(name = "SUPABASE_URL_PROD"),
       )
     }
 

--- a/app/src/main/java/app/kaito_dogi/mybrary/MainActivity.kt
+++ b/app/src/main/java/app/kaito_dogi/mybrary/MainActivity.kt
@@ -100,8 +100,10 @@ internal class MainActivity : AppCompatActivity() {
 
             settingDestination(startDestination = SettingRoute.SettingList) {
               settingListScreen(
+                onTermsOfUseClick = internalBrowserLauncher::launch,
+                onPrivacyPolicyClick = internalBrowserLauncher::launch,
                 onLicenceClick = {},
-                onRakutenClick = internalBrowserLauncher::launch,
+                onRakutenDevelopersClick = internalBrowserLauncher::launch,
               )
             }
           }

--- a/app/src/main/java/app/kaito_dogi/mybrary/MainActivity.kt
+++ b/app/src/main/java/app/kaito_dogi/mybrary/MainActivity.kt
@@ -8,15 +8,17 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+import app.kaito_dogi.mybrary.core.ui.browser.InternalBrowserLauncher
 import app.kaito_dogi.mybrary.core.ui.exception.ExceptionConsumer
 import app.kaito_dogi.mybrary.core.ui.exception.ExceptionConsumerEntryPoint
 import app.kaito_dogi.mybrary.core.ui.navigation.MybraryNavHost
 import app.kaito_dogi.mybrary.core.ui.navigation.bar.mainNavGraph
-import app.kaito_dogi.mybrary.core.ui.navigation.route.MybraryRoute
 import app.kaito_dogi.mybrary.core.ui.navigation.route.AuthRoute
 import app.kaito_dogi.mybrary.core.ui.navigation.route.MainRoute
 import app.kaito_dogi.mybrary.core.ui.navigation.route.MyBookRoute
+import app.kaito_dogi.mybrary.core.ui.navigation.route.MybraryRoute
 import app.kaito_dogi.mybrary.core.ui.navigation.route.SearchBookRoute
 import app.kaito_dogi.mybrary.core.ui.navigation.route.SettingRoute
 import app.kaito_dogi.mybrary.feature.auth.authNavGraph
@@ -25,9 +27,9 @@ import app.kaito_dogi.mybrary.feature.auth.destination.verifyotp.navigateToVerif
 import app.kaito_dogi.mybrary.feature.auth.destination.verifyotp.verifyOtpScreen
 import app.kaito_dogi.mybrary.feature.mybook.destination.mybookdetail.myBookDetailScreen
 import app.kaito_dogi.mybrary.feature.mybook.destination.mybookdetail.navigateToMyBookDetailScreen
-import app.kaito_dogi.mybrary.feature.mybook.myBookDestination
 import app.kaito_dogi.mybrary.feature.mybook.destination.mybooklist.myBookListScreen
 import app.kaito_dogi.mybrary.feature.mybook.destination.mybooklist.navigateToMyBookListScreen
+import app.kaito_dogi.mybrary.feature.mybook.myBookDestination
 import app.kaito_dogi.mybrary.feature.searchbook.destination.searchbook.navigateToSearchBookScreen
 import app.kaito_dogi.mybrary.feature.searchbook.destination.searchbook.searchBookScreen
 import app.kaito_dogi.mybrary.feature.searchbook.searchBookNavGraph
@@ -61,7 +63,7 @@ internal class MainActivity : AppCompatActivity() {
         }
 
         // FIXME: ログイン状態に応じて startDestination を変更する
-        MybraryNavHost(startDestination = MybraryRoute.Auth) { navController ->
+        MybraryNavHost(startDestination = MybraryRoute.Auth) { navController: NavHostController, internalBrowserLauncher: InternalBrowserLauncher ->
           authNavGraph(startDestination = AuthRoute.SendOtp) {
             sendOtpScreen(
               onSendOtpComplete = { email, page ->
@@ -97,7 +99,10 @@ internal class MainActivity : AppCompatActivity() {
             }
 
             settingDestination(startDestination = SettingRoute.SettingList) {
-              settingListScreen()
+              settingListScreen(
+                onLicenceClick = {},
+                onRakutenClick = internalBrowserLauncher::launch,
+              )
             }
           }
         }

--- a/app/src/main/java/app/kaito_dogi/mybrary/MybraryConfigModule.kt
+++ b/app/src/main/java/app/kaito_dogi/mybrary/MybraryConfigModule.kt
@@ -13,9 +13,10 @@ internal object MybraryConfigModule {
   @Singleton
   @Provides
   fun provideMybraryConfig(): MybraryConfig = object : MybraryConfig {
-    override val supabaseUrl: String = BuildConfig.SUPABASE_URL
-    override val supabaseKey: String = BuildConfig.SUPABASE_KEY
     override val rakutenApplicationId: String = BuildConfig.RAKUTEN_APPLICATION_ID
     override val rakutenAffiliateId: String = BuildConfig.RAKUTEN_AFFILIATE_ID
+    override val supabaseUrl: String = BuildConfig.SUPABASE_URL
+    override val supabaseKey: String = BuildConfig.SUPABASE_KEY
+    override val versionName: String = BuildConfig.VERSION_NAME
   }
 }

--- a/app/src/main/java/app/kaito_dogi/mybrary/MybraryConfigModule.kt
+++ b/app/src/main/java/app/kaito_dogi/mybrary/MybraryConfigModule.kt
@@ -1,5 +1,6 @@
 package app.kaito_dogi.mybrary
 
+import app.kaito_dogi.mybrary.core.common.model.Url
 import app.kaito_dogi.mybrary.core.config.MybraryConfig
 import dagger.Module
 import dagger.Provides
@@ -13,10 +14,16 @@ internal object MybraryConfigModule {
   @Singleton
   @Provides
   fun provideMybraryConfig(): MybraryConfig = object : MybraryConfig {
+    override val privacyPolicyUrl: Url.Web
+      get() = TODO("Not yet implemented")
     override val rakutenApplicationId: String = BuildConfig.RAKUTEN_APPLICATION_ID
     override val rakutenAffiliateId: String = BuildConfig.RAKUTEN_AFFILIATE_ID
+    override val rakutenDevelopersUrl: Url.Web
+      get() = TODO("Not yet implemented")
     override val supabaseUrl: String = BuildConfig.SUPABASE_URL
     override val supabaseKey: String = BuildConfig.SUPABASE_KEY
+    override val termsOfUseUrl: Url.Web
+      get() = TODO("Not yet implemented")
     override val versionName: String = BuildConfig.VERSION_NAME
   }
 }

--- a/app/src/main/java/app/kaito_dogi/mybrary/MybraryConfigModule.kt
+++ b/app/src/main/java/app/kaito_dogi/mybrary/MybraryConfigModule.kt
@@ -14,16 +14,13 @@ internal object MybraryConfigModule {
   @Singleton
   @Provides
   fun provideMybraryConfig(): MybraryConfig = object : MybraryConfig {
-    override val privacyPolicyUrl: Url.Web
-      get() = TODO("Not yet implemented")
+    override val privacyPolicyUrl: Url.Web = Url.Web(value = BuildConfig.PRIVACY_POLICY_URL)
     override val rakutenApplicationId: String = BuildConfig.RAKUTEN_APPLICATION_ID
     override val rakutenAffiliateId: String = BuildConfig.RAKUTEN_AFFILIATE_ID
-    override val rakutenDevelopersUrl: Url.Web
-      get() = TODO("Not yet implemented")
+    override val rakutenDevelopersUrl: Url.Web = Url.Web(value = BuildConfig.RAKUTEN_DEVELOPERS_URL)
     override val supabaseUrl: String = BuildConfig.SUPABASE_URL
     override val supabaseKey: String = BuildConfig.SUPABASE_KEY
-    override val termsOfUseUrl: Url.Web
-      get() = TODO("Not yet implemented")
+    override val termsOfUseUrl: Url.Web = Url.Web(value = BuildConfig.TERMS_OF_USE)
     override val versionName: String = BuildConfig.VERSION_NAME
   }
 }

--- a/core/common/src/main/java/app/kaito_dogi/mybrary/core/common/model/Url.kt
+++ b/core/common/src/main/java/app/kaito_dogi/mybrary/core/common/model/Url.kt
@@ -14,4 +14,9 @@ sealed interface Url {
   data class Image(
     override val value: String,
   ) : Url
+
+  @Serializable
+  data class Web(
+    override val value: String,
+  ) : Url
 }

--- a/core/config/build.gradle.kts
+++ b/core/config/build.gradle.kts
@@ -7,3 +7,7 @@ java {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17
 }
+
+dependencies {
+  implementation(project(":core:common"))
+}

--- a/core/config/src/main/java/app/kaito_dogi/mybrary/core/config/MybraryConfig.kt
+++ b/core/config/src/main/java/app/kaito_dogi/mybrary/core/config/MybraryConfig.kt
@@ -1,9 +1,14 @@
 package app.kaito_dogi.mybrary.core.config
 
+import app.kaito_dogi.mybrary.core.common.model.Url
+
 interface MybraryConfig {
+  val privacyPolicyUrl: Url.Web
   val rakutenApplicationId: String
   val rakutenAffiliateId: String
+  val rakutenDevelopersUrl: Url.Web
   val supabaseUrl: String
   val supabaseKey: String
+  val termsOfUseUrl: Url.Web
   val versionName: String
 }

--- a/core/config/src/main/java/app/kaito_dogi/mybrary/core/config/MybraryConfig.kt
+++ b/core/config/src/main/java/app/kaito_dogi/mybrary/core/config/MybraryConfig.kt
@@ -1,8 +1,9 @@
 package app.kaito_dogi.mybrary.core.config
 
 interface MybraryConfig {
-  val supabaseUrl: String
-  val supabaseKey: String
   val rakutenApplicationId: String
   val rakutenAffiliateId: String
+  val supabaseUrl: String
+  val supabaseKey: String
+  val versionName: String
 }

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/ext/WindowInsetsExt.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/ext/WindowInsetsExt.kt
@@ -1,0 +1,8 @@
+package app.kaito_dogi.mybrary.core.designsystem.ext
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.Composable
+
+val WindowInsets.Companion.none: WindowInsets
+  @Composable
+  get() = WindowInsets(0, 0, 0, 0)

--- a/core/design-system/src/main/res/drawable/icon_arrow_forward.xml
+++ b/core/design-system/src/main/res/drawable/icon_arrow_forward.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M12.6,12L8,7.4L9.4,6L15.4,12L9.4,18L8,16.6L12.6,12Z"
+        android:fillColor="#ffffff"/>
+  </group>
+</vector>

--- a/core/design-system/src/main/res/values-ja/strings.xml
+++ b/core/design-system/src/main/res/values-ja/strings.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string name="setting_list_text_about">このアプリについて</string>
+  <string name="setting_list_text_account">アカウント</string>
+  <string name="setting_list_text_license">ライセンス</string>
+  <string name="setting_list_text_make_notes_public_by_default">メモをデフォルトで公開する</string>
+  <string name="setting_list_text_privacy_policy">プライバシーポリシー</string>
+  <string name="setting_list_text_terms_of_use">利用規約</string>
   <string name="ui_alt_my_book">Mybrary に移動する</string>
   <string name="ui_alt_setting">設定に移動する</string>
   <string name="ui_text_my_book">Mybrary</string>

--- a/core/design-system/src/main/res/values-ja/strings.xml
+++ b/core/design-system/src/main/res/values-ja/strings.xml
@@ -9,6 +9,7 @@
   <string name="setting_list_text_others">その他</string>
   <string name="setting_list_text_privacy_policy">プライバシーポリシー</string>
   <string name="setting_list_text_setting">設定</string>
+  <string name="setting_list_text_supported_by_rakuten_developers">Supported by Rakuten Developers</string>
   <string name="setting_list_text_terms_of_use">利用規約</string>
   <string name="setting_list_text_version">バージョン</string>
   <string name="ui_alt_my_book">Mybrary に移動する</string>

--- a/core/design-system/src/main/res/values-ja/strings.xml
+++ b/core/design-system/src/main/res/values-ja/strings.xml
@@ -5,6 +5,7 @@
   <string name="setting_list_text_license">ライセンス</string>
   <string name="setting_list_text_make_notes_public_by_default">メモをデフォルトで公開する</string>
   <string name="setting_list_text_privacy_policy">プライバシーポリシー</string>
+  <string name="setting_list_text_setting">設定</string>
   <string name="setting_list_text_terms_of_use">利用規約</string>
   <string name="ui_alt_my_book">Mybrary に移動する</string>
   <string name="ui_alt_setting">設定に移動する</string>

--- a/core/design-system/src/main/res/values-ja/strings.xml
+++ b/core/design-system/src/main/res/values-ja/strings.xml
@@ -10,6 +10,7 @@
   <string name="setting_list_text_privacy_policy">プライバシーポリシー</string>
   <string name="setting_list_text_setting">設定</string>
   <string name="setting_list_text_terms_of_use">利用規約</string>
+  <string name="setting_list_text_version">バージョン</string>
   <string name="ui_alt_my_book">Mybrary に移動する</string>
   <string name="ui_alt_setting">設定に移動する</string>
   <string name="ui_text_my_book">Mybrary</string>

--- a/core/design-system/src/main/res/values-ja/strings.xml
+++ b/core/design-system/src/main/res/values-ja/strings.xml
@@ -2,8 +2,11 @@
 <resources>
   <string name="setting_list_text_about">このアプリについて</string>
   <string name="setting_list_text_account">アカウント</string>
+  <string name="setting_list_text_delete_account">アカウントを削除する</string>
   <string name="setting_list_text_license">ライセンス</string>
+  <string name="setting_list_text_logout">ログアウト</string>
   <string name="setting_list_text_make_notes_public_by_default">メモをデフォルトで公開する</string>
+  <string name="setting_list_text_others">その他</string>
   <string name="setting_list_text_privacy_policy">プライバシーポリシー</string>
   <string name="setting_list_text_setting">設定</string>
   <string name="setting_list_text_terms_of_use">利用規約</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -2,8 +2,11 @@
 <resources>
   <string name="setting_list_text_about">About</string>
   <string name="setting_list_text_account">Account</string>
+  <string name="setting_list_text_delete_account">Delete account</string>
   <string name="setting_list_text_license">License</string>
+  <string name="setting_list_text_logout">Logout</string>
   <string name="setting_list_text_make_notes_public_by_default">Make notes public by default</string>
+  <string name="setting_list_text_others">Others</string>
   <string name="setting_list_text_privacy_policy">Privacy Policy</string>
   <string name="setting_list_text_setting">Settings</string>
   <string name="setting_list_text_terms_of_use">Terms of Use</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
   <string name="setting_list_text_others">Others</string>
   <string name="setting_list_text_privacy_policy">Privacy Policy</string>
   <string name="setting_list_text_setting">Settings</string>
+  <string name="setting_list_text_supported_by_rakuten_developers">Supported by Rakuten Developers</string>
   <string name="setting_list_text_terms_of_use">Terms of Use</string>
   <string name="setting_list_text_version">Version</string>
   <string name="ui_alt_my_book">Go to Mybrary destination</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string name="setting_list_text_about">About</string>
+  <string name="setting_list_text_account">Account</string>
+  <string name="setting_list_text_license">License</string>
+  <string name="setting_list_text_make_notes_public_by_default">Make notes public by default</string>
+  <string name="setting_list_text_privacy_policy">Privacy Policy</string>
+  <string name="setting_list_text_terms_of_use">Terms of Use</string>
   <string name="ui_alt_my_book">Go to Mybrary destination</string>
   <string name="ui_alt_setting">Go to Settings destination</string>
   <string name="ui_text_my_book">Mybrary</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
   <string name="setting_list_text_privacy_policy">Privacy Policy</string>
   <string name="setting_list_text_setting">Settings</string>
   <string name="setting_list_text_terms_of_use">Terms of Use</string>
+  <string name="setting_list_text_version">Version</string>
   <string name="ui_alt_my_book">Go to Mybrary destination</string>
   <string name="ui_alt_setting">Go to Settings destination</string>
   <string name="ui_text_my_book">Mybrary</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
   <string name="setting_list_text_license">License</string>
   <string name="setting_list_text_make_notes_public_by_default">Make notes public by default</string>
   <string name="setting_list_text_privacy_policy">Privacy Policy</string>
+  <string name="setting_list_text_setting">Settings</string>
   <string name="setting_list_text_terms_of_use">Terms of Use</string>
   <string name="ui_alt_my_book">Go to Mybrary destination</string>
   <string name="ui_alt_setting">Go to Settings destination</string>

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   implementation(project(":core:design-system"))
   implementation(project(":core:domain"))
 
+  implementation(libs.androidx.browser)
   implementation(platform(libs.androidxComposeBom))
   implementation(libs.androidxComposeMaterial3)
   implementation(libs.androidxComposeUiTooling)

--- a/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/browser/InternalBrowserLauncher.kt
+++ b/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/browser/InternalBrowserLauncher.kt
@@ -1,0 +1,58 @@
+package app.kaito_dogi.mybrary.core.ui.browser
+
+import android.graphics.BitmapFactory
+import androidx.browser.customtabs.CustomTabColorSchemeParams
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.net.toUri
+import app.kaito_dogi.mybrary.core.common.model.Url
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+import app.kaito_dogi.mybrary.core.ui.R
+
+interface InternalBrowserLauncher {
+  fun launch(url: Url)
+}
+
+@Composable
+fun rememberInternalBrowserLauncher(): InternalBrowserLauncher {
+  val context = LocalContext.current
+
+  val closeButtonIcon = remember(context) {
+    BitmapFactory.decodeResource(
+      context.resources,
+      R.drawable.icon_arrow_back,
+    )
+  }
+
+  val toolbarColor = MybraryTheme.colorScheme.surface.toArgb()
+  val customTabColorSchemeParams = remember(toolbarColor) {
+    CustomTabColorSchemeParams.Builder()
+      .setToolbarColor(toolbarColor)
+      .build()
+  }
+
+  val customTabsIntent = remember(
+    closeButtonIcon,
+    customTabColorSchemeParams,
+  ) {
+    CustomTabsIntent.Builder()
+      .setShowTitle(true)
+      .setCloseButtonIcon(closeButtonIcon)
+      .setDefaultColorSchemeParams(customTabColorSchemeParams)
+      .build()
+  }
+
+  val internalBrowserLauncher = remember {
+    object : InternalBrowserLauncher {
+      override fun launch(url: Url) {
+        val uri = url.value.toUri()
+        customTabsIntent.launchUrl(context, uri)
+      }
+    }
+  }
+
+  return internalBrowserLauncher
+}

--- a/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/navigation/MybraryNavHost.kt
+++ b/core/ui/src/main/java/app/kaito_dogi/mybrary/core/ui/navigation/MybraryNavHost.kt
@@ -16,6 +16,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import app.kaito_dogi.mybrary.core.ui.browser.InternalBrowserLauncher
+import app.kaito_dogi.mybrary.core.ui.browser.rememberInternalBrowserLauncher
 import app.kaito_dogi.mybrary.core.ui.navigation.bar.MainNavigationBar
 import app.kaito_dogi.mybrary.core.ui.navigation.bar.NavigationBarDestination
 import app.kaito_dogi.mybrary.core.ui.navigation.route.MainRoute
@@ -25,9 +27,11 @@ import app.kaito_dogi.mybrary.core.ui.navigation.route.MybraryRoute
 fun MybraryNavHost(
   startDestination: MybraryRoute,
   modifier: Modifier = Modifier,
-  builder: NavGraphBuilder.(NavHostController) -> Unit,
+  builder: NavGraphBuilder.(NavHostController, InternalBrowserLauncher) -> Unit,
 ) {
   val navController = rememberNavController()
+  val internalBrowserLauncher = rememberInternalBrowserLauncher()
+
   val currentBackStackEntry by navController.currentBackStackEntryAsState()
   val hierarchy = currentBackStackEntry?.destination?.hierarchy
 
@@ -37,7 +41,7 @@ fun MybraryNavHost(
     NavHost(
       navController = navController,
       startDestination = startDestination,
-      builder = { builder(navController) },
+      builder = { builder(navController, internalBrowserLauncher) },
       modifier = Modifier.fillMaxSize(),
     )
 

--- a/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/component/MyBookListHeader.kt
+++ b/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/component/MyBookListHeader.kt
@@ -1,11 +1,11 @@
 package app.kaito_dogi.mybrary.feature.mybook.destination.mybooklist.component
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,11 +18,11 @@ internal fun MyBookListHeader(
   @StringRes titleResId: Int,
   modifier: Modifier = Modifier,
 ) {
-  Column(
+  Box(
     modifier = modifier
       .fillMaxWidth()
       .height(MybraryTheme.dimens.topAppBarHeight - MybraryTheme.spaces.sm * 2),
-    verticalArrangement = Arrangement.Center,
+    contentAlignment = Alignment.CenterStart,
   ) {
     Text(
       text = stringResource(id = titleResId),

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -36,6 +36,7 @@ android {
 
 dependencies {
   implementation(project(":core:common"))
+  implementation(project(":core:config"))
   implementation(project(":core:design-system"))
   implementation(project(":core:domain"))
   implementation(project(":core:ui"))

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListNavigation.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListNavigation.kt
@@ -3,11 +3,21 @@ package app.kaito_dogi.mybrary.feature.setting.destination.settinglist
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import app.kaito_dogi.mybrary.core.common.model.Url
 import app.kaito_dogi.mybrary.core.ui.navigation.route.SettingRoute
 
 fun NavGraphBuilder.settingListScreen(
+  onTermsOfUseClick: (Url) -> Unit,
+  onPrivacyPolicyClick: (Url) -> Unit,
+  onLicenceClick: () -> Unit,
+  onRakutenDevelopersClick: (Url) -> Unit,
 ) = composable<SettingRoute.SettingList> {
-  SettingListScreenContainer()
+  SettingListScreenContainer(
+    onTermsOfUseClick = onTermsOfUseClick,
+    onPrivacyPolicyClick = onPrivacyPolicyClick,
+    onLicenceClick = onLicenceClick,
+    onRakutenDevelopersClick = onRakutenDevelopersClick,
+  )
 }
 
 fun NavHostController.navigateToSettingListScreen() = this.navigate(route = SettingRoute.SettingList)

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreen.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreen.kt
@@ -37,8 +37,10 @@ internal fun SettingListScreen(
       item {
         SettingSwitch(
           titleResId = R.string.setting_list_text_make_notes_public_by_default,
-          isChecked = true,
-          onClick = {},
+          isChecked = uiState.isMemoMadePublicByDefault,
+          onClick = {
+            // TODO: 実装する
+          },
         )
       }
 
@@ -96,13 +98,17 @@ internal fun SettingListScreen(
       item {
         SettingDanger(
           titleResId = R.string.setting_list_text_logout,
-          onClick = {},
+          onClick = {
+            // TODO: 実装する
+          },
         )
       }
       item {
         SettingDanger(
           titleResId = R.string.setting_list_text_delete_account,
-          onClick = {},
+          onClick = {
+            // TODO: 実装する
+          },
         )
       }
     }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreen.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreen.kt
@@ -1,0 +1,130 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.common.model.Url
+import app.kaito_dogi.mybrary.core.designsystem.R
+import app.kaito_dogi.mybrary.core.designsystem.component.NavigationBarContentScaffold
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+import app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component.SettingDanger
+import app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component.SettingHeader
+import app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component.SettingListDivider
+import app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component.SettingListTopAppBar
+import app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component.SettingRow
+import app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component.SettingSwitch
+
+@Composable
+internal fun SettingListScreen(
+  uiState: SettingListUiState,
+  onTermsOfUseClick: () -> Unit,
+  onPrivacyPolicyClick: () -> Unit,
+  onLicenceClick: () -> Unit,
+  onRakutenDevelopersClick: () -> Unit,
+) {
+  NavigationBarContentScaffold { innerPadding ->
+    LazyColumn(contentPadding = innerPadding) {
+      item {
+        SettingListTopAppBar()
+      }
+
+      // アカウント
+      item {
+        SettingHeader(titleResId = R.string.setting_list_text_account)
+      }
+      item {
+        SettingSwitch(
+          titleResId = R.string.setting_list_text_make_notes_public_by_default,
+          isChecked = true,
+          onClick = {},
+        )
+      }
+
+      item {
+        SettingListDivider(
+          modifier = Modifier.padding(horizontal = MybraryTheme.spaces.sm),
+        )
+      }
+
+      // アプリについて
+      item {
+        SettingHeader(titleResId = R.string.setting_list_text_about)
+      }
+      item {
+        SettingRow(
+          titleResId = R.string.setting_list_text_terms_of_use,
+          onClick = onTermsOfUseClick,
+        )
+      }
+      item {
+        SettingRow(
+          titleResId = R.string.setting_list_text_privacy_policy,
+          onClick = onPrivacyPolicyClick,
+        )
+      }
+      item {
+        SettingRow(
+          titleResId = R.string.setting_list_text_license,
+          onClick = onLicenceClick,
+        )
+      }
+      item {
+        SettingRow(
+          titleResId = R.string.setting_list_text_supported_by_rakuten_developers,
+          onClick = onRakutenDevelopersClick,
+        )
+      }
+      item {
+        SettingRow(
+          titleResId = R.string.setting_list_text_version,
+          supportingText = uiState.versionName,
+        )
+      }
+
+      item {
+        SettingListDivider(
+          modifier = Modifier.padding(horizontal = MybraryTheme.spaces.md),
+        )
+      }
+
+      // その他
+      item {
+        SettingHeader(titleResId = R.string.setting_list_text_others)
+      }
+      item {
+        SettingDanger(
+          titleResId = R.string.setting_list_text_logout,
+          onClick = {},
+        )
+      }
+      item {
+        SettingDanger(
+          titleResId = R.string.setting_list_text_delete_account,
+          onClick = {},
+        )
+      }
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun SettingListScreenPreview() {
+  MybraryTheme {
+    SettingListScreen(
+      uiState = SettingListUiState(
+        isMemoMadePublicByDefault = false,
+        termsOfUseUrl = Url.Web(value = ""),
+        privacyPolicyUrl = Url.Web(value = ""),
+        rakutenDevelopersUrl = Url.Web(value = ""),
+        versionName = "0.0.1",
+      ),
+      onTermsOfUseClick = {},
+      onPrivacyPolicyClick = {},
+      onLicenceClick = {},
+      onRakutenDevelopersClick = {},
+    )
+  }
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreen.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreen.kt
@@ -19,10 +19,13 @@ import app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component.
 @Composable
 internal fun SettingListScreen(
   uiState: SettingListUiState,
+  onSwitchClick: (Boolean) -> Unit,
   onTermsOfUseClick: () -> Unit,
   onPrivacyPolicyClick: () -> Unit,
   onLicenceClick: () -> Unit,
   onRakutenDevelopersClick: () -> Unit,
+  onLogoutClick: () -> Unit,
+  onDeleteAccountClick: () -> Unit,
 ) {
   NavigationBarContentScaffold { innerPadding ->
     LazyColumn(contentPadding = innerPadding) {
@@ -38,9 +41,7 @@ internal fun SettingListScreen(
         SettingSwitch(
           titleResId = R.string.setting_list_text_make_notes_public_by_default,
           isChecked = uiState.isMemoMadePublicByDefault,
-          onClick = {
-            // TODO: 実装する
-          },
+          onClick = onSwitchClick,
         )
       }
 
@@ -98,17 +99,13 @@ internal fun SettingListScreen(
       item {
         SettingDanger(
           titleResId = R.string.setting_list_text_logout,
-          onClick = {
-            // TODO: 実装する
-          },
+          onClick = onLogoutClick,
         )
       }
       item {
         SettingDanger(
           titleResId = R.string.setting_list_text_delete_account,
-          onClick = {
-            // TODO: 実装する
-          },
+          onClick = onDeleteAccountClick,
         )
       }
     }
@@ -127,10 +124,13 @@ private fun SettingListScreenPreview() {
         rakutenDevelopersUrl = Url.Web(value = ""),
         versionName = "0.0.1",
       ),
+      onSwitchClick = {},
       onTermsOfUseClick = {},
       onPrivacyPolicyClick = {},
       onLicenceClick = {},
       onRakutenDevelopersClick = {},
+      onLogoutClick = {},
+      onDeleteAccountClick = {},
     )
   }
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreenContainer.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreenContainer.kt
@@ -1,24 +1,26 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.kaito_dogi.mybrary.core.common.model.Url
 
 @Composable
-internal fun SettingListScreenContainer() {
-  Box(
-    modifier = Modifier
-      .fillMaxSize()
-      .padding(WindowInsets.navigationBars.asPaddingValues()),
-    contentAlignment = Alignment.Center,
-  ) {
-    Text(text = "SettingList")
-  }
+internal fun SettingListScreenContainer(
+  onTermsOfUseClick: (Url) -> Unit,
+  onPrivacyPolicyClick: (Url) -> Unit,
+  onLicenceClick: () -> Unit,
+  onRakutenDevelopersClick: (Url) -> Unit,
+  viewModel: SettingListViewModel = hiltViewModel(),
+) {
+  val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+  SettingListScreen(
+    uiState = uiState,
+    onTermsOfUseClick = { onTermsOfUseClick(uiState.termsOfUseUrl) },
+    onPrivacyPolicyClick = { onPrivacyPolicyClick(uiState.privacyPolicyUrl) },
+    onLicenceClick = onLicenceClick,
+    onRakutenDevelopersClick = { onRakutenDevelopersClick(uiState.rakutenDevelopersUrl) },
+  )
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreenContainer.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListScreenContainer.kt
@@ -18,9 +18,12 @@ internal fun SettingListScreenContainer(
 
   SettingListScreen(
     uiState = uiState,
+    onSwitchClick = viewModel::onSwitchClick,
     onTermsOfUseClick = { onTermsOfUseClick(uiState.termsOfUseUrl) },
     onPrivacyPolicyClick = { onPrivacyPolicyClick(uiState.privacyPolicyUrl) },
     onLicenceClick = onLicenceClick,
     onRakutenDevelopersClick = { onRakutenDevelopersClick(uiState.rakutenDevelopersUrl) },
+    onLogoutClick = viewModel::onLogoutClick,
+    onDeleteAccountClick = viewModel::onDeleteAccountClick,
   )
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListUiState.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListUiState.kt
@@ -18,7 +18,7 @@ internal data class SettingListUiState(
       rakutenDevelopersUrl: Url.Web,
       versionName: String,
     ) = SettingListUiState(
-      isMemoMadePublicByDefault = false,
+      isMemoMadePublicByDefault = true,
       termsOfUseUrl = termsOfUseUrl,
       privacyPolicyUrl = privacyPolicyUrl,
       rakutenDevelopersUrl = rakutenDevelopersUrl,

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListUiState.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListUiState.kt
@@ -1,0 +1,28 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist
+
+import androidx.compose.runtime.Immutable
+import app.kaito_dogi.mybrary.core.common.model.Url
+
+@Immutable
+internal data class SettingListUiState(
+  val isMemoMadePublicByDefault: Boolean,
+  val termsOfUseUrl: Url.Web,
+  val privacyPolicyUrl: Url.Web,
+  val rakutenDevelopersUrl: Url.Web,
+  val versionName: String,
+) {
+  companion object {
+    fun createInitialValue(
+      termsOfUseUrl: Url.Web,
+      privacyPolicyUrl: Url.Web,
+      rakutenDevelopersUrl: Url.Web,
+      versionName: String,
+    ) = SettingListUiState(
+      isMemoMadePublicByDefault = false,
+      termsOfUseUrl = termsOfUseUrl,
+      privacyPolicyUrl = privacyPolicyUrl,
+      rakutenDevelopersUrl = rakutenDevelopersUrl,
+      versionName = versionName,
+    )
+  }
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListViewModel.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListViewModel.kt
@@ -20,4 +20,16 @@ internal class SettingListViewModel @Inject constructor(
     ),
   )
   val uiState = _uiState.asStateFlow()
+
+  fun onSwitchClick(value: Boolean) {
+    // TODO: 実装する
+  }
+
+  fun onLogoutClick() {
+    // TODO: 実装する
+  }
+
+  fun onDeleteAccountClick() {
+    // TODO: 実装する
+  }
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListViewModel.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/SettingListViewModel.kt
@@ -1,0 +1,23 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist
+
+import androidx.lifecycle.ViewModel
+import app.kaito_dogi.mybrary.core.config.MybraryConfig
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@HiltViewModel
+internal class SettingListViewModel @Inject constructor(
+  config: MybraryConfig,
+) : ViewModel() {
+  private val _uiState = MutableStateFlow(
+    SettingListUiState.createInitialValue(
+      termsOfUseUrl = config.termsOfUseUrl,
+      privacyPolicyUrl = config.privacyPolicyUrl,
+      rakutenDevelopersUrl = config.rakutenDevelopersUrl,
+      versionName = config.versionName,
+    ),
+  )
+  val uiState = _uiState.asStateFlow()
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingDanger.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingDanger.kt
@@ -12,13 +12,13 @@ internal fun SettingDanger(
   @StringRes titleResId: Int,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
-  @StringRes supportingTextResId: Int? = null,
+  supportingText: String? = null,
 ) {
   SettingRowScaffold(
     titleResId = titleResId,
     modifier = modifier,
     isDanger = true,
-    supportingTextResId = supportingTextResId,
+    supportingText = supportingText,
     onClick = onClick,
   )
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingDanger.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingDanger.kt
@@ -1,0 +1,36 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.R
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+internal fun SettingDanger(
+  @StringRes titleResId: Int,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  @StringRes supportingTextResId: Int? = null,
+) {
+  SettingRowScaffold(
+    titleResId = titleResId,
+    modifier = modifier,
+    isDanger = true,
+    supportingTextResId = supportingTextResId,
+    onClick = onClick,
+  )
+}
+
+@Preview
+@Composable
+private fun SettingDangerPreview(
+) {
+  MybraryTheme {
+    SettingDanger(
+      titleResId = R.string.setting_list_text_logout,
+      onClick = {},
+    )
+  }
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
@@ -1,0 +1,43 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.R
+import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+internal fun SettingHeader(
+  @StringRes titleResId: Int,
+  modifier: Modifier = Modifier,
+) {
+  Box(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(MybraryTheme.spaces.sm),
+    contentAlignment = Alignment.CenterStart,
+  ) {
+    Text(
+      text = stringResource(titleResId),
+      color = MybraryTheme.colorScheme.onSurfaceVariant,
+      style = MybraryTheme.typography.titleLarge,
+    )
+  }
+}
+
+@Preview
+@Composable
+private fun SettingHeaderPreview() {
+  MybraryTheme {
+    SettingHeader(
+      titleResId = R.string.setting_list_text_account,
+    )
+  }
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
@@ -21,10 +21,7 @@ internal fun SettingHeader(
   Box(
     modifier = modifier
       .fillMaxWidth()
-      .padding(
-        horizontal = MybraryTheme.spaces.xs,
-        vertical = MybraryTheme.spaces.sm,
-      ),
+      .padding(MybraryTheme.spaces.md),
     contentAlignment = Alignment.CenterStart,
   ) {
     Text(

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
@@ -21,13 +21,17 @@ internal fun SettingHeader(
   Box(
     modifier = modifier
       .fillMaxWidth()
-      .padding(horizontal = MybraryTheme.spaces.xs),
+      .padding(
+        start = MybraryTheme.spaces.xs,
+        end = MybraryTheme.spaces.xs,
+        bottom = MybraryTheme.spaces.xs,
+      ),
     contentAlignment = Alignment.CenterStart,
   ) {
     Text(
       text = stringResource(titleResId),
       color = MybraryTheme.colorScheme.onSurfaceVariant,
-      style = MybraryTheme.typography.titleLarge,
+      style = MybraryTheme.typography.titleMedium,
     )
   }
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
@@ -21,7 +21,10 @@ internal fun SettingHeader(
   Box(
     modifier = modifier
       .fillMaxWidth()
-      .padding(MybraryTheme.spaces.md),
+      .padding(
+        horizontal = MybraryTheme.spaces.md,
+        vertical = MybraryTheme.spaces.sm,
+      ),
     contentAlignment = Alignment.CenterStart,
   ) {
     Text(

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
@@ -22,9 +22,8 @@ internal fun SettingHeader(
     modifier = modifier
       .fillMaxWidth()
       .padding(
-        start = MybraryTheme.spaces.xs,
-        end = MybraryTheme.spaces.xs,
-        bottom = MybraryTheme.spaces.xs,
+        horizontal = MybraryTheme.spaces.xs,
+        vertical = MybraryTheme.spaces.sm,
       ),
     contentAlignment = Alignment.CenterStart,
   ) {

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
@@ -1,6 +1,7 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -20,6 +21,7 @@ internal fun SettingHeader(
 ) {
   Box(
     modifier = modifier
+      .background(MybraryTheme.colorScheme.background)
       .fillMaxWidth()
       .padding(
         horizontal = MybraryTheme.spaces.md,

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingHeader.kt
@@ -21,7 +21,7 @@ internal fun SettingHeader(
   Box(
     modifier = modifier
       .fillMaxWidth()
-      .padding(MybraryTheme.spaces.sm),
+      .padding(horizontal = MybraryTheme.spaces.xs),
     contentAlignment = Alignment.CenterStart,
   ) {
     Text(

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingListDivider.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingListDivider.kt
@@ -1,7 +1,5 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
@@ -16,8 +14,8 @@ internal fun SettingListDivider(
 ) {
   HorizontalDivider(
     modifier = modifier
-        .padding(vertical = MybraryTheme.spaces.md)
-        .fillMaxWidth(),
+      .padding(vertical = MybraryTheme.spaces.md)
+      .fillMaxWidth(),
     color = MybraryTheme.colorScheme.surfaceVariant,
   )
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingListDivider.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingListDivider.kt
@@ -1,0 +1,32 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+internal fun SettingListDivider(
+  modifier: Modifier = Modifier,
+) {
+  HorizontalDivider(
+    modifier = modifier
+        .padding(vertical = MybraryTheme.spaces.md)
+        .fillMaxWidth(),
+    color = MybraryTheme.colorScheme.surfaceVariant,
+  )
+}
+
+@Preview
+@Composable
+private fun SettingListDividerPreview(
+) {
+  MybraryTheme {
+    SettingListDivider()
+  }
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingListTopAppBar.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingListTopAppBar.kt
@@ -1,27 +1,32 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
-import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.R
 import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.ext.none
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SettingListTopAppBar(
-  @StringRes titleResId: Int,
+  modifier: Modifier = Modifier,
 ) {
+  // FIXME: NavigationBarItem で表示できる NavHost の Root の TopAppBar として共通化する
   CenterAlignedTopAppBar(
     title = {
       Text(
-        text = stringResource(titleResId),
+        text = stringResource(R.string.setting_list_text_setting),
         style = MybraryTheme.typography.headlineSmall,
       )
     },
+    modifier = modifier,
+    windowInsets = WindowInsets.none,
   )
 }
 
@@ -29,6 +34,6 @@ internal fun SettingListTopAppBar(
 @Composable
 private fun SettingListTopAppBarPreview() {
   MybraryTheme {
-    SettingListTopAppBar(titleResId = R.string.setting_list_text_setting)
+    SettingListTopAppBar()
   }
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
@@ -1,7 +1,6 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -20,8 +19,9 @@ internal fun SettingRow(
 ) {
   SettingRowScaffold(
     titleResId = titleResId,
-    modifier = modifier.clickable(enabled = onClick != null) { onClick?.invoke() },
+    modifier = modifier,
     supportingTextResId = supportingTextResId,
+    onClick = onClick,
     trailingContent = {
       onClick?.let {
         Icon(

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
@@ -1,15 +1,20 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
-import androidx.compose.material3.IconButton
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
 import app.kaito_dogi.mybrary.core.designsystem.R
 import app.kaito_dogi.mybrary.core.designsystem.component.Icon
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+private val IconContainerSize = 48.dp
 
 @Composable
 internal fun SettingRow(
@@ -25,7 +30,10 @@ internal fun SettingRow(
     onClick = onClick,
     trailingContent = {
       onClick?.let {
-        IconButton(it) {
+        Box(
+          modifier = Modifier.size(IconContainerSize),
+          contentAlignment = Alignment.Center,
+        ) {
           Icon(
             iconResId = R.drawable.icon_arrow_forward,
             altResId = titleResId,

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
@@ -1,0 +1,79 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.R
+import app.kaito_dogi.mybrary.core.designsystem.component.Icon
+import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+internal fun SettingRow(
+  @StringRes titleResId: Int,
+  modifier: Modifier = Modifier,
+  @StringRes supportingTextResId: Int? = null,
+  onClick: (() -> Unit)? = null,
+) {
+  Row(
+    modifier = modifier
+      .clip(MybraryTheme.shapes.small)
+      .clickable(enabled = onClick != null) { onClick?.invoke() }
+      .fillMaxWidth()
+      .padding(MybraryTheme.spaces.sm),
+    horizontalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xxs),
+    ) {
+      Text(
+        text = stringResource(titleResId),
+        color = MybraryTheme.colorScheme.onSurface,
+        maxLines = 1,
+        style = MybraryTheme.typography.bodyLarge,
+      )
+      supportingTextResId?.let {
+        Text(
+          text = stringResource(it),
+          color = MybraryTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          style = MybraryTheme.typography.bodySmall,
+        )
+      }
+    }
+    onClick?.let {
+      Icon(
+        iconResId = R.drawable.icon_arrow_forward,
+        altResId = titleResId,
+        tint = MybraryTheme.colorScheme.onSurface,
+      )
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun SettingRowPreview() {
+  MybraryTheme {
+    Box(modifier = Modifier.background(MybraryTheme.colorScheme.surface)) {
+      SettingRow(
+        titleResId = R.string.setting_list_text_terms_of_use,
+        onClick = {},
+      )
+    }
+  }
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
@@ -1,23 +1,14 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import app.kaito_dogi.mybrary.core.designsystem.R
 import app.kaito_dogi.mybrary.core.designsystem.component.Icon
-import app.kaito_dogi.mybrary.core.designsystem.component.Text
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 
 @Composable
@@ -27,53 +18,47 @@ internal fun SettingRow(
   @StringRes supportingTextResId: Int? = null,
   onClick: (() -> Unit)? = null,
 ) {
-  Row(
-    modifier = modifier
-      .clip(MybraryTheme.shapes.small)
-      .clickable(enabled = onClick != null) { onClick?.invoke() }
-      .fillMaxWidth()
-      .padding(MybraryTheme.spaces.sm),
-    horizontalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
-    verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Column(
-      modifier = Modifier.weight(1f),
-      verticalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xxs),
-    ) {
-      Text(
-        text = stringResource(titleResId),
-        color = MybraryTheme.colorScheme.onSurface,
-        maxLines = 1,
-        style = MybraryTheme.typography.bodyLarge,
-      )
-      supportingTextResId?.let {
-        Text(
-          text = stringResource(it),
-          color = MybraryTheme.colorScheme.onSurfaceVariant,
-          maxLines = 1,
-          style = MybraryTheme.typography.bodySmall,
+  SettingRowScaffold(
+    titleResId = titleResId,
+    modifier = modifier.clickable(enabled = onClick != null) { onClick?.invoke() },
+    supportingTextResId = supportingTextResId,
+    trailingContent = {
+      onClick?.let {
+        Icon(
+          iconResId = R.drawable.icon_arrow_forward,
+          altResId = titleResId,
+          tint = MybraryTheme.colorScheme.onSurface,
         )
       }
-    }
-    onClick?.let {
-      Icon(
-        iconResId = R.drawable.icon_arrow_forward,
-        altResId = titleResId,
-        tint = MybraryTheme.colorScheme.onSurface,
-      )
-    }
-  }
+    },
+  )
 }
 
 @Preview
 @Composable
-private fun SettingRowPreview() {
+private fun SettingRowPreview(
+  @PreviewParameter(SettingRowPreviewParameterProvider::class) parameter: SettingRowPreviewParameter,
+) {
   MybraryTheme {
-    Box(modifier = Modifier.background(MybraryTheme.colorScheme.surface)) {
-      SettingRow(
-        titleResId = R.string.setting_list_text_terms_of_use,
-        onClick = {},
-      )
-    }
+    SettingRow(
+      titleResId = R.string.setting_list_text_terms_of_use,
+      onClick = parameter.onClick,
+    )
   }
 }
+
+private class SettingRowPreviewParameterProvider : PreviewParameterProvider<SettingRowPreviewParameter> {
+  override val values: Sequence<SettingRowPreviewParameter>
+    get() = sequenceOf(
+      SettingRowPreviewParameter(
+        onClick = null,
+      ),
+      SettingRowPreviewParameter(
+        onClick = {},
+      ),
+    )
+}
+
+private data class SettingRowPreviewParameter(
+  val onClick: (() -> Unit)?,
+)

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
@@ -1,6 +1,7 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,11 +25,13 @@ internal fun SettingRow(
     onClick = onClick,
     trailingContent = {
       onClick?.let {
-        Icon(
-          iconResId = R.drawable.icon_arrow_forward,
-          altResId = titleResId,
-          tint = MybraryTheme.colorScheme.onSurface,
-        )
+        IconButton(it) {
+          Icon(
+            iconResId = R.drawable.icon_arrow_forward,
+            altResId = titleResId,
+            tint = MybraryTheme.colorScheme.onSurface,
+          )
+        }
       }
     },
   )

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRow.kt
@@ -20,13 +20,13 @@ private val IconContainerSize = 48.dp
 internal fun SettingRow(
   @StringRes titleResId: Int,
   modifier: Modifier = Modifier,
-  @StringRes supportingTextResId: Int? = null,
+  supportingText: String? = null,
   onClick: (() -> Unit)? = null,
 ) {
   SettingRowScaffold(
     titleResId = titleResId,
     modifier = modifier,
-    supportingTextResId = supportingTextResId,
+    supportingText = supportingText,
     onClick = onClick,
     trailingContent = {
       onClick?.let {

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
@@ -1,6 +1,7 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,13 +20,15 @@ internal fun SettingRowScaffold(
   @StringRes titleResId: Int,
   modifier: Modifier = Modifier,
   @StringRes supportingTextResId: Int? = null,
+  onClick: (() -> Unit)? = null,
   trailingContent: @Composable () -> Unit,
 ) {
   Row(
     modifier = modifier
       .clip(MybraryTheme.shapes.small)
+      .clickable(enabled = onClick != null) { onClick?.invoke() }
       .fillMaxWidth()
-      .padding(MybraryTheme.spaces.sm),
+      .padding(MybraryTheme.spaces.xs),
     horizontalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
     verticalAlignment = Alignment.CenterVertically,
   ) {

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
@@ -1,0 +1,53 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+internal fun SettingRowScaffold(
+  @StringRes titleResId: Int,
+  modifier: Modifier = Modifier,
+  @StringRes supportingTextResId: Int? = null,
+  trailingContent: @Composable () -> Unit,
+) {
+  Row(
+    modifier = modifier
+      .clip(MybraryTheme.shapes.small)
+      .fillMaxWidth()
+      .padding(MybraryTheme.spaces.sm),
+    horizontalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xxs),
+    ) {
+      Text(
+        text = stringResource(titleResId),
+        color = MybraryTheme.colorScheme.onSurface,
+        maxLines = 1,
+        style = MybraryTheme.typography.bodyLarge,
+      )
+      supportingTextResId?.let {
+        Text(
+          text = stringResource(it),
+          color = MybraryTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          style = MybraryTheme.typography.bodySmall,
+        )
+      }
+    }
+    trailingContent()
+  }
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
@@ -28,10 +28,7 @@ internal fun SettingRowScaffold(
       .clip(MybraryTheme.shapes.small)
       .clickable(enabled = onClick != null) { onClick?.invoke() }
       .fillMaxWidth()
-      .padding(
-        horizontal = MybraryTheme.spaces.xs,
-        vertical = MybraryTheme.spaces.sm,
-      ),
+      .padding(horizontal = MybraryTheme.spaces.xs),
     horizontalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
     verticalAlignment = Alignment.CenterVertically,
   ) {

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
@@ -1,34 +1,40 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import app.kaito_dogi.mybrary.core.designsystem.component.Text
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+private val MinHeight = 56.dp
 
 @Composable
 internal fun SettingRowScaffold(
   @StringRes titleResId: Int,
   modifier: Modifier = Modifier,
+  isDanger: Boolean = false,
   @StringRes supportingTextResId: Int? = null,
   onClick: (() -> Unit)? = null,
-  trailingContent: @Composable () -> Unit,
+  trailingContent: (@Composable () -> Unit)? = null,
 ) {
   Row(
     modifier = modifier
-      .clip(MybraryTheme.shapes.small)
       .clickable(enabled = onClick != null) { onClick?.invoke() }
+      .background(MybraryTheme.colorScheme.background)
       .fillMaxWidth()
-      .padding(horizontal = MybraryTheme.spaces.xs),
+      .defaultMinSize(minHeight = MinHeight)
+      .padding(horizontal = MybraryTheme.spaces.md),
     horizontalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
     verticalAlignment = Alignment.CenterVertically,
   ) {
@@ -38,7 +44,7 @@ internal fun SettingRowScaffold(
     ) {
       Text(
         text = stringResource(titleResId),
-        color = MybraryTheme.colorScheme.onSurface,
+        color = if (isDanger) MybraryTheme.colorScheme.error else MybraryTheme.colorScheme.onSurface,
         maxLines = 1,
         style = MybraryTheme.typography.bodyLarge,
       )
@@ -51,6 +57,6 @@ internal fun SettingRowScaffold(
         )
       }
     }
-    trailingContent()
+    trailingContent?.invoke()
   }
 }

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
@@ -28,7 +28,10 @@ internal fun SettingRowScaffold(
       .clip(MybraryTheme.shapes.small)
       .clickable(enabled = onClick != null) { onClick?.invoke() }
       .fillMaxWidth()
-      .padding(MybraryTheme.spaces.xs),
+      .padding(
+        horizontal = MybraryTheme.spaces.xs,
+        vertical = MybraryTheme.spaces.sm,
+      ),
     horizontalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
     verticalAlignment = Alignment.CenterVertically,
   ) {

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingRowScaffold.kt
@@ -21,10 +21,10 @@ private val MinHeight = 56.dp
 
 @Composable
 internal fun SettingRowScaffold(
-  @StringRes titleResId: Int,
+  @StringRes titleResId: Int, // FIXME: String 型にする
   modifier: Modifier = Modifier,
   isDanger: Boolean = false,
-  @StringRes supportingTextResId: Int? = null,
+  supportingText: String? = null,
   onClick: (() -> Unit)? = null,
   trailingContent: (@Composable () -> Unit)? = null,
 ) {
@@ -48,9 +48,9 @@ internal fun SettingRowScaffold(
         maxLines = 1,
         style = MybraryTheme.typography.bodyLarge,
       )
-      supportingTextResId?.let {
+      supportingText?.let {
         Text(
-          text = stringResource(it),
+          text = it,
           color = MybraryTheme.colorScheme.onSurfaceVariant,
           maxLines = 1,
           style = MybraryTheme.typography.bodySmall,

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingSwitch.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingSwitch.kt
@@ -11,7 +11,7 @@ import app.kaito_dogi.mybrary.core.designsystem.R
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 
 @Composable
-internal fun SettingSwitchRow(
+internal fun SettingSwitch(
   @StringRes titleResId: Int,
   isChecked: Boolean,
   onClick: (Boolean) -> Unit,
@@ -24,9 +24,10 @@ internal fun SettingSwitchRow(
     supportingTextResId = supportingTextResId,
     onClick = { onClick(!isChecked) },
     trailingContent = {
+      // Composable 全体をクリック領域とするため、Switch 自体には onClick を渡さず、リップルを無効にする
       Switch(
         checked = isChecked,
-        onCheckedChange = onClick,
+        onCheckedChange = null,
       )
     },
   )
@@ -34,11 +35,11 @@ internal fun SettingSwitchRow(
 
 @Preview
 @Composable
-private fun SettingSwitchRowPreview(
+private fun SettingSwitchPreview(
   @PreviewParameter(SettingSwitchRowPreviewParameterProvider::class) parameter: SettingSwitchRowPreviewParameter,
 ) {
   MybraryTheme {
-    SettingSwitchRow(
+    SettingSwitch(
       titleResId = R.string.setting_list_text_make_notes_public_by_default,
       isChecked = parameter.isChecked,
       onClick = {},

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingSwitch.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingSwitch.kt
@@ -16,12 +16,12 @@ internal fun SettingSwitch(
   isChecked: Boolean,
   onClick: (Boolean) -> Unit,
   modifier: Modifier = Modifier,
-  @StringRes supportingTextResId: Int? = null,
+  supportingText: String? = null,
 ) {
   SettingRowScaffold(
     titleResId = titleResId,
     modifier = modifier,
-    supportingTextResId = supportingTextResId,
+    supportingText = supportingText,
     onClick = { onClick(!isChecked) },
     trailingContent = {
       // Composable 全体をクリック領域とするため、Switch 自体には onClick を渡さず、リップルを無効にする

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingSwitchRow.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingSwitchRow.kt
@@ -1,0 +1,63 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import app.kaito_dogi.mybrary.core.designsystem.R
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@Composable
+internal fun SettingSwitchRow(
+  @StringRes titleResId: Int,
+  isChecked: Boolean,
+  onClick: (Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+  @StringRes supportingTextResId: Int? = null,
+) {
+  SettingRowScaffold(
+    titleResId = titleResId,
+    modifier = modifier.clickable { onClick(!isChecked) },
+    supportingTextResId = supportingTextResId,
+    trailingContent = {
+      Switch(
+        checked = isChecked,
+        onCheckedChange = onClick,
+      )
+    },
+  )
+}
+
+@Preview
+@Composable
+private fun SettingSwitchRowPreview(
+  @PreviewParameter(SettingSwitchRowPreviewParameterProvider::class) parameter: SettingSwitchRowPreviewParameter,
+) {
+  MybraryTheme {
+    SettingSwitchRow(
+      titleResId = R.string.setting_list_text_make_notes_public_by_default,
+      isChecked = parameter.isChecked,
+      onClick = {},
+    )
+  }
+}
+
+private class SettingSwitchRowPreviewParameterProvider : PreviewParameterProvider<SettingSwitchRowPreviewParameter> {
+  override val values: Sequence<SettingSwitchRowPreviewParameter>
+    get() = sequenceOf(
+      SettingSwitchRowPreviewParameter(
+        isChecked = true,
+      ),
+      SettingSwitchRowPreviewParameter(
+        isChecked = false,
+      ),
+    )
+}
+
+private data class SettingSwitchRowPreviewParameter(
+  val isChecked: Boolean,
+)

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingSwitchRow.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingSwitchRow.kt
@@ -1,7 +1,6 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.clickable
 import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -21,8 +20,9 @@ internal fun SettingSwitchRow(
 ) {
   SettingRowScaffold(
     titleResId = titleResId,
-    modifier = modifier.clickable { onClick(!isChecked) },
+    modifier = modifier,
     supportingTextResId = supportingTextResId,
+    onClick = { onClick(!isChecked) },
     trailingContent = {
       Switch(
         checked = isChecked,

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingTopAppBar.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingTopAppBar.kt
@@ -1,0 +1,34 @@
+package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
+
+import androidx.annotation.StringRes
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.R
+import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SettingListTopAppBar(
+  @StringRes titleResId: Int,
+) {
+  TopAppBar(
+    title = {
+      Text(
+        text = stringResource(titleResId),
+        style = MybraryTheme.typography.headlineSmall,
+      )
+    },
+  )
+}
+
+@Preview
+@Composable
+private fun SettingListTopAppBarPreview() {
+  MybraryTheme {
+    SettingListTopAppBar(titleResId = R.string.setting_list_text_setting)
+  }
+}

--- a/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingTopAppBar.kt
+++ b/feature/setting/src/main/java/app/kaito_dogi/mybrary/feature/setting/destination/settinglist/component/SettingTopAppBar.kt
@@ -1,8 +1,8 @@
 package app.kaito_dogi.mybrary.feature.setting.destination.settinglist.component
 
 import androidx.annotation.StringRes
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -15,7 +15,7 @@ import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 internal fun SettingListTopAppBar(
   @StringRes titleResId: Int,
 ) {
-  TopAppBar(
+  CenterAlignedTopAppBar(
     title = {
       Text(
         text = stringResource(titleResId),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,9 @@
+# FIXME: ケバブケースに置き換える
+# FIXME: module を使用する
+
 [versions]
 androidGradlePlugin = "8.5.0"
+androidx-browser = "1.8.0"
 androidxComposeBom = "2024.06.00"
 androidxComposeCompiler = "1.5.14"
 androidxEspresso = "3.6.0"
@@ -29,6 +33,7 @@ versionCode = "1"
 versionName = "0.0.1"
 
 [libraries]
+androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 androidxComposeBom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidxComposeMaterial3 = { group = "androidx.compose.material3", name = "material3" }
 androidxComposeUiTooling = { group = "androidx.compose.ui", name = "ui-tooling" }


### PR DESCRIPTION
## :thought_balloon: 背景


## :sparkles: 実装内容

- 設定画面の実装
- 内部ブラウザの実装（CustomTabsIntent）
- 利用規約へのリンク
- プライバシーポリシーへのリンク
- Raukuten Developers へのリンク

## :white_check_mark: 動作確認

- [ ] `記入する`

## :art: UI 差分

| Before | After |
|:--:|:--:|
| <img src="" width="300px" /> | <img src="https://github.com/user-attachments/assets/e97a09b5-134f-484b-bc33-c80bb28f9576" width="300px" /><br /><img src="https://github.com/user-attachments/assets/53f990eb-da9d-4563-87b1-243cfbdecc14" width="300px" /> |

## :link: 関連リンク

- 利用規約：https://kaito-dogi.notion.site/10a57cd8a9f680b2adc0d4db1ffd9715
- プライバシーポリシー：https://kaito-dogi.notion.site/4fbba3e6fdcf4ac29210a8e8223661bf
- Raukuten Developers：https://developers.rakuten.com/
