### PR TITLE
UI の調整

### DIFF
--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/theme/Dimens.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/theme/Dimens.kt
@@ -9,7 +9,6 @@ internal val mybraryDimens = Dimens(
   bookWidthSm = 96.dp,
   bookWidthMd = 120.dp,
   navigationBarHeight = 80.dp,
-  topAppBarHeight = 64.dp,
 )
 
 @Immutable
@@ -17,14 +16,12 @@ data class Dimens(
   val bookWidthSm: Dp,
   val bookWidthMd: Dp,
   val navigationBarHeight: Dp,
-  val topAppBarHeight: Dp,
 )
 
 private val defaultDimens = Dimens(
   bookWidthSm = Dp.Hairline,
   bookWidthMd = Dp.Hairline,
   navigationBarHeight = Dp.Hairline,
-  topAppBarHeight = Dp.Hairline,
 )
 
 internal val LocalDimens = staticCompositionLocalOf { defaultDimens }

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/sendotp/SendOtpScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/sendotp/SendOtpScreen.kt
@@ -68,14 +68,14 @@ internal fun SendOtpScreen(
         onEmailChange = onEmailChange,
         onSendOtpClick = onSendOtpClick,
         modifier = Modifier
-          .padding(horizontal = MybraryTheme.spaces.xl)
+          .padding(horizontal = MybraryTheme.spaces.md)
           .imePadding(),
       )
 
       Gap(height = MybraryTheme.spaces.xl)
 
       DividerSection(
-        modifier = Modifier.padding(horizontal = MybraryTheme.spaces.xl),
+        modifier = Modifier.padding(horizontal = MybraryTheme.spaces.md),
       )
 
       Gap(height = MybraryTheme.spaces.xl)
@@ -83,7 +83,7 @@ internal fun SendOtpScreen(
       HorizontalPager(
         modifier = Modifier.weight(1f),
         state = pagerState,
-        contentPadding = PaddingValues(horizontal = MybraryTheme.spaces.xl),
+        contentPadding = PaddingValues(horizontal = MybraryTheme.spaces.md),
         pageSpacing = MybraryTheme.spaces.xl,
       ) { page ->
         when (page) {

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/sendotp/SendOtpScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/sendotp/SendOtpScreen.kt
@@ -46,7 +46,7 @@ internal fun SendOtpScreen(
         .background(
           brush = Brush.linearGradient(
             colors = listOf(
-              MybraryTheme.colorScheme.background,
+              MybraryTheme.colorScheme.surface,
               MybraryTheme.colorScheme.secondaryContainer,
               MybraryTheme.colorScheme.errorContainer,
             ),

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/sendotp/component/HorizontalPagerIndicator.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/sendotp/component/HorizontalPagerIndicator.kt
@@ -36,7 +36,7 @@ internal fun HorizontalPagerIndicator(
           .clip(CircleShape)
           .background(
             if (it.ordinal == currentPage) MybraryTheme.colorScheme.primary
-            else MybraryTheme.colorScheme.outline,
+            else MybraryTheme.colorScheme.outlineVariant,
           ),
       )
     }

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/verifyotp/VerifyOtpScreen.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/verifyotp/VerifyOtpScreen.kt
@@ -18,11 +18,11 @@ import app.kaito_dogi.mybrary.core.designsystem.component.PrimaryButton
 import app.kaito_dogi.mybrary.core.designsystem.component.TertiaryButton
 import app.kaito_dogi.mybrary.core.designsystem.component.Text
 import app.kaito_dogi.mybrary.core.designsystem.component.TextField
-import app.kaito_dogi.mybrary.core.designsystem.component.TopAppBar
 import app.kaito_dogi.mybrary.core.designsystem.ext.plus
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.R
 import app.kaito_dogi.mybrary.core.ui.navigation.route.AuthRoute
+import app.kaito_dogi.mybrary.feature.auth.destination.verifyotp.component.VerifyOtpTopAppBar
 
 @Composable
 internal fun VerifyOtpScreen(
@@ -34,12 +34,7 @@ internal fun VerifyOtpScreen(
 ) {
   Scaffold(
     topBar = {
-      TopAppBar(
-        textResId = R.string.verify_otp_text_verify_otp,
-        navigationIconResId = R.drawable.icon_arrow_back,
-        navigationIconAltResId = R.string.verify_otp_back,
-        onNavigationIconClick = onNavigationIconClick,
-      )
+      VerifyOtpTopAppBar(onNavigationIconClick = onNavigationIconClick)
     },
   ) { innerPadding ->
     Column(

--- a/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/verifyotp/component/VerifyOtpTopAppBar.kt
+++ b/feature/auth/src/main/java/app/kaito_dogi/mybrary/feature/auth/destination/verifyotp/component/VerifyOtpTopAppBar.kt
@@ -1,0 +1,44 @@
+package app.kaito_dogi.mybrary.feature.auth.destination.verifyotp.component
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MediumTopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import app.kaito_dogi.mybrary.core.designsystem.component.Icon
+import app.kaito_dogi.mybrary.core.designsystem.component.Text
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
+import app.kaito_dogi.mybrary.core.ui.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun VerifyOtpTopAppBar(
+  onNavigationIconClick: () -> Unit,
+) {
+  MediumTopAppBar(
+    title = {
+      Text(text = stringResource(id = R.string.verify_otp_text_verify_otp))
+    },
+    navigationIcon = {
+      IconButton(
+        onClick = onNavigationIconClick,
+      ) {
+        Icon(
+          iconResId = R.drawable.icon_arrow_back,
+          altResId = R.string.verify_otp_back,
+        )
+      }
+    },
+  )
+}
+
+@Preview
+@Composable
+private fun VerifyOtpTopAppBarPreview() {
+  MybraryTheme {
+    VerifyOtpTopAppBar(
+      onNavigationIconClick = {},
+    )
+  }
+}

--- a/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/MyBookListScreen.kt
+++ b/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/MyBookListScreen.kt
@@ -82,7 +82,7 @@ internal fun MyBookListScreen(
             span = { GridItemSpan(uiState.numberOfColumns) },
             key = "Spacer:favorite",
           ) {
-            Spacer(modifier = Modifier.height(MybraryTheme.spaces.xl))
+            Spacer(modifier = Modifier.height(MybraryTheme.spaces.sm))
           }
         }
       }

--- a/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/component/MyBookListHeader.kt
+++ b/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/component/MyBookListHeader.kt
@@ -3,9 +3,7 @@ package app.kaito_dogi.mybrary.feature.mybook.destination.mybooklist.component
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,15 +17,12 @@ internal fun MyBookListHeader(
   modifier: Modifier = Modifier,
 ) {
   Box(
-    modifier = modifier
-      .fillMaxWidth()
-      .height(MybraryTheme.dimens.topAppBarHeight - MybraryTheme.spaces.sm * 2),
-    contentAlignment = Alignment.CenterStart,
+    modifier = modifier.fillMaxWidth(),
   ) {
     Text(
       text = stringResource(id = titleResId),
       color = MybraryTheme.colorScheme.onBackground,
-      style = MybraryTheme.typography.titleLarge,
+      style = MybraryTheme.typography.headlineSmall,
     )
   }
 }

--- a/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/component/MyBookListHeaderSkeleton.kt
+++ b/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/component/MyBookListHeaderSkeleton.kt
@@ -1,7 +1,6 @@
 package app.kaito_dogi.mybrary.feature.mybook.destination.mybooklist.component
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,14 +17,12 @@ internal fun MyBookListHeaderSkeleton(
 ) {
   SkeletonBox(
     shape = MybraryTheme.shapes.extraSmall,
-    modifier = modifier
-      .fillMaxWidth()
-      .height(MybraryTheme.dimens.topAppBarHeight - MybraryTheme.spaces.sm * 2),
+    modifier = modifier.fillMaxWidth(),
   ) {
     Text(
       text = stringResource(id = R.string.my_book_list_text_a),
       color = Color.Transparent,
-      style = MybraryTheme.typography.titleLarge,
+      style = MybraryTheme.typography.headlineSmall,
     )
   }
 }


### PR DESCRIPTION
## :thought_balloon: 背景


## :sparkles: 実装内容

- MyBookList
  - Header の高さを調整
  - セクション間の余白を調整
- VerifyOtp
  - TopAppBar を Medium にした
- SendOtp
  - グラデーション修正
  - 画面左右端の余白を調整
  - Indicator の色を修正

## :white_check_mark: 動作確認

- [ ] `記入する`

## :art: UI 差分

| Before | After |
|:--:|:--:|
| <img src="" width="300px" /> | <img src="" width="300px" /> |

## :link: 関連リンク

