### PR TITLE
ワンタイムパスワードの再送信処理を実装

### DIFF
--- a/core/data/src/main/java/app/kaito_dogi/mybrary/core/data/datasource/AuthRemoteDataSource.kt
+++ b/core/data/src/main/java/app/kaito_dogi/mybrary/core/data/datasource/AuthRemoteDataSource.kt
@@ -17,6 +17,11 @@ interface AuthRemoteDataSource {
     captchaToken: String,
   )
 
+  suspend fun resendOtp(
+    email: String,
+    captchaToken: String,
+  )
+
   suspend fun googleSignIn()
 
   suspend fun googleSignUp()

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/AlertDialog.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/AlertDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -34,7 +35,7 @@ fun AlertDialog(
   },
   confirmButton = {
     TertiaryButton(
-      textResId = confirmTextResId,
+      text = stringResource(id = confirmTextResId),
       onClick = onConfirmClick,
       isLoading = isConfirmLoading,
       isEnabled = !isDismissLoading,
@@ -44,7 +45,7 @@ fun AlertDialog(
   dismissButton = if (dismissTextResId != null && onDismissClick != null) {
     {
       TertiaryButton(
-        textResId = dismissTextResId,
+        text = stringResource(id = dismissTextResId),
         onClick = onDismissClick,
         isLoading = isDismissLoading,
         isEnabled = !isConfirmLoading,

--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/TertiaryButton.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/component/TertiaryButton.kt
@@ -23,7 +23,7 @@ import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 
 @Composable
 fun TertiaryButton(
-  @StringRes textResId: Int,
+  text: String,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
   @DrawableRes iconResId: Int? = null,
@@ -60,7 +60,7 @@ fun TertiaryButton(
     Gap(width = ButtonDefaults.IconSpacing)
   }
 
-  Text(text = stringResource(id = textResId))
+  Text(text = text)
 }
 
 @Preview(showBackground = true)
@@ -70,7 +70,7 @@ private fun TertiaryButtonPreview(
 ) {
   MybraryTheme {
     TertiaryButton(
-      textResId = android.R.string.unknownName,
+      text = "TertiaryButton",
       onClick = {},
       modifier = Modifier.fillMaxWidth(),
       isLoading = parameter.isLoading,

--- a/core/design-system/src/main/res/values-ja/strings.xml
+++ b/core/design-system/src/main/res/values-ja/strings.xml
@@ -84,6 +84,7 @@
   <string name="verify_otp_text_it_may_take_a_few_minutes">ワンタイムパスワードが届くまで数分かかる場合があります。</string>
   <string name="verify_otp_text_login">ログイン</string>
   <string name="verify_otp_text_resend_otp">もう一度ワンタイムパスワードを送信する</string>
+  <string name="verify_otp_text_resend_otp_in_seconds">もう一度ワンタイムパスワードを送信する（あと%1$d秒）</string>
   <string name="verify_otp_text_sign_up">サインアップ</string>
   <string name="verify_otp_text_verify_otp">ワンタイムパスワードの認証</string>
 </resources>

--- a/core/design-system/src/main/res/values-ja/strings.xml
+++ b/core/design-system/src/main/res/values-ja/strings.xml
@@ -83,7 +83,7 @@
   <string name="verify_otp_text_enter_otp_sent_to">%1$sに送信されたワンタイムパスワードを入力してください。</string>
   <string name="verify_otp_text_it_may_take_a_few_minutes">ワンタイムパスワードが届くまで数分かかる場合があります。</string>
   <string name="verify_otp_text_login">ログイン</string>
-  <string name="verify_otp_text_resend_otp">もう一度ワンタイムパスワードを送信</string>
+  <string name="verify_otp_text_resend_otp">もう一度ワンタイムパスワードを送信する</string>
   <string name="verify_otp_text_sign_up">サインアップ</string>
   <string name="verify_otp_text_verify_otp">ワンタイムパスワードの認証</string>
 </resources>

--- a/core/design-system/src/main/res/values-ja/strings.xml
+++ b/core/design-system/src/main/res/values-ja/strings.xml
@@ -62,7 +62,7 @@
   <string name="sign_up_alt_sign_up_with_google">Google アカウントで始める</string>
   <string name="sign_up_alt_your_email">メールアドレス</string>
   <string name="sign_up_placeholder_enter_your_email">メールアドレス</string>
-  <string name="sign_up_text_already_have_an_account_login">ログインは</string>
+  <string name="sign_up_text_already_have_an_account_sign_in">ログインは</string>
   <string name="sign_up_text_continue_as_anonymous">ゲストで始めてみる</string>
   <string name="sign_up_text_here">こちら</string>
   <string name="sign_up_text_send_otp">ワンタイムパスワードを送信する</string>
@@ -82,7 +82,7 @@
   <string name="verify_otp_placeholder_enter_otp">123456</string>
   <string name="verify_otp_text_enter_otp_sent_to">%1$sに送信されたワンタイムパスワードを入力してください。</string>
   <string name="verify_otp_text_it_may_take_a_few_minutes">ワンタイムパスワードが届くまで数分かかる場合があります。</string>
-  <string name="verify_otp_text_login">ログイン</string>
+  <string name="verify_otp_text_sign_in">ログイン</string>
   <string name="verify_otp_text_resend_otp">もう一度ワンタイムパスワードを送信する</string>
   <string name="verify_otp_text_resend_otp_in_seconds">もう一度ワンタイムパスワードを送信する（あと%1$d秒）</string>
   <string name="verify_otp_text_sign_up">サインアップ</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
   <string name="verify_otp_text_it_may_take_a_few_minutes">It may take a few minutes to receive the one-time password.</string>
   <string name="verify_otp_text_login">Login</string>
   <string name="verify_otp_text_resend_otp">Resend One-Time Password</string>
+  <string name="verify_otp_text_resend_otp_in_seconds">Resend One-Time Password (in %1$d seconds)</string>
   <string name="verify_otp_text_sign_up">Sign up</string>
   <string name="verify_otp_text_verify_otp">Verify One-Time Password</string>
 </resources>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
   <string name="sign_up_alt_sign_up_with_google">Sign up with Google</string>
   <string name="sign_up_alt_your_email">Your Email</string>
   <string name="sign_up_placeholder_enter_your_email">Your Email</string>
-  <string name="sign_up_text_already_have_an_account_login">"Already have an account? Login "</string>
+  <string name="sign_up_text_already_have_an_account_sign_in">"Already have an account? Sign in "</string>
   <string name="sign_up_text_continue_as_anonymous">Continue as anonymous</string>
   <string name="sign_up_text_here">here</string>
   <string name="sign_up_text_send_otp">Send One-Time Password</string>
@@ -82,7 +82,7 @@
   <string name="verify_otp_placeholder_enter_otp">123456</string>
   <string name="verify_otp_text_enter_otp_sent_to">Enter the One-Time Password sent to %1$s.</string>
   <string name="verify_otp_text_it_may_take_a_few_minutes">It may take a few minutes to receive the one-time password.</string>
-  <string name="verify_otp_text_login">Login</string>
+  <string name="verify_otp_text_sign_in">Sign in</string>
   <string name="verify_otp_text_resend_otp">Resend One-Time Password</string>
   <string name="verify_otp_text_resend_otp_in_seconds">Resend One-Time Password (in %1$d seconds)</string>
   <string name="verify_otp_text_sign_up">Sign up</string>

--- a/core/domain/src/main/java/app/kaito_dogi/mybrary/core/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/app/kaito_dogi/mybrary/core/domain/repository/AuthRepository.kt
@@ -19,6 +19,11 @@ interface AuthRepository {
     captchaToken: CaptchaToken,
   )
 
+  suspend fun resendOtp(
+    email: String,
+    captchaToken: CaptchaToken,
+  )
+
   suspend fun googleSignIn()
 
   suspend fun googleSignUp()

--- a/core/repository-mock/src/main/java/app/kaito_dogi/mybrary/core/repository/mock/MockAuthRepository.kt
+++ b/core/repository-mock/src/main/java/app/kaito_dogi/mybrary/core/repository/mock/MockAuthRepository.kt
@@ -28,6 +28,13 @@ internal class MockAuthRepository @Inject constructor() : AuthRepository {
     delay(1_000)
   }
 
+  override suspend fun resendOtp(
+    email: String,
+    captchaToken: CaptchaToken,
+  ) {
+    delay(1_000)
+  }
+
   override suspend fun googleSignIn() {
     delay(1_000L)
   }

--- a/core/repository/src/main/java/app/kaito_dogi/mybrary/core/repository/DefaultAuthRepository.kt
+++ b/core/repository/src/main/java/app/kaito_dogi/mybrary/core/repository/DefaultAuthRepository.kt
@@ -40,6 +40,16 @@ internal class DefaultAuthRepository @Inject constructor(
     )
   }
 
+  override suspend fun resendOtp(
+    email: String,
+    captchaToken: CaptchaToken,
+  ) {
+    authRemoteDataSource.resendOtp(
+      email = email,
+      captchaToken = captchaToken.value,
+    )
+  }
+
   override suspend fun googleSignIn() {
     authRemoteDataSource.googleSignIn()
   }

--- a/core/supabase/src/main/java/app/kaito_dogi/mybrary/core/supabase/datasource/DefaultAuthRemoteDataSource.kt
+++ b/core/supabase/src/main/java/app/kaito_dogi/mybrary/core/supabase/datasource/DefaultAuthRemoteDataSource.kt
@@ -54,6 +54,17 @@ internal class DefaultAuthRemoteDataSource @Inject constructor(
     )
   }
 
+  override suspend fun resendOtp(
+    email: String,
+    captchaToken: String,
+  ) = withContext(dispatcher) {
+    supabaseClient.auth.resendEmail(
+      type = OtpType.Email.SIGNUP,
+      email = email,
+      captchaToken = captchaToken,
+    )
+  }
+
   override suspend fun googleSignIn() = withContext(dispatcher) {
     TODO("Not yet implemented")
   }

--- a/feature/sign-in/src/main/java/app/kaito_dogi/mybrary/feature/signin/SignInScreen.kt
+++ b/feature/sign-in/src/main/java/app/kaito_dogi/mybrary/feature/signin/SignInScreen.kt
@@ -72,7 +72,7 @@ internal fun SignInScreen(
 
       Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
+        verticalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.sm),
       ) {
         SecondaryButton(
           textResId = R.string.sign_in_text_sign_in_with_google,

--- a/feature/sign-up/src/main/java/app/kaito_dogi/mybrary/feature/signup/SignUpScreen.kt
+++ b/feature/sign-up/src/main/java/app/kaito_dogi/mybrary/feature/signup/SignUpScreen.kt
@@ -74,7 +74,7 @@ internal fun SignUpScreen(
 
       Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.xs),
+        verticalArrangement = Arrangement.spacedBy(MybraryTheme.spaces.sm),
       ) {
         SecondaryButton(
           textResId = R.string.sign_up_text_sign_up_with_google,

--- a/feature/sign-up/src/main/java/app/kaito_dogi/mybrary/feature/signup/component/NavigateToSignInSection.kt
+++ b/feature/sign-up/src/main/java/app/kaito_dogi/mybrary/feature/signup/component/NavigateToSignInSection.kt
@@ -29,7 +29,7 @@ internal fun NavigateToSignInSection(
         color = MybraryTheme.colorScheme.outline,
       ),
     ) {
-      append(context.getString(R.string.sign_up_text_already_have_an_account_login))
+      append(context.getString(R.string.sign_up_text_already_have_an_account_sign_in))
     }
 
     withLink(

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -75,7 +75,7 @@ internal fun VerifyOtpScreen(
 
       PrimaryButton(
         textResId = when (uiState.source) {
-          AuthRoute.VerifyOtp.Source.SignIn -> R.string.verify_otp_text_login
+          AuthRoute.VerifyOtp.Source.SignIn -> R.string.verify_otp_text_sign_in
           AuthRoute.VerifyOtp.Source.SignUp -> R.string.verify_otp_text_sign_up
         },
         onClick = onVerifyOtpClick,

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -41,7 +41,13 @@ internal fun VerifyOtpScreen(
     Column(
       modifier = Modifier
         .fillMaxSize()
-        .padding(innerPadding.plus(horizontal = MybraryTheme.spaces.md)),
+        .padding(
+          innerPadding.plus(
+            start = MybraryTheme.spaces.md,
+            end = MybraryTheme.spaces.md,
+            bottom = MybraryTheme.spaces.xs,
+          ),
+        ),
     ) {
       Text(
         text = stringResource(
@@ -87,9 +93,7 @@ internal fun VerifyOtpScreen(
 
       ResendOtpButton(
         onClick = onResendOtpClick,
-        modifier = Modifier
-          .padding(bottom = MybraryTheme.spaces.sm)
-          .fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth(),
         isLoading = uiState.isOtpResending,
       )
     }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -18,11 +18,11 @@ import app.kaito_dogi.mybrary.core.common.model.CaptchaToken
 import app.kaito_dogi.mybrary.core.designsystem.R
 import app.kaito_dogi.mybrary.core.designsystem.component.Gap
 import app.kaito_dogi.mybrary.core.designsystem.component.PrimaryButton
-import app.kaito_dogi.mybrary.core.designsystem.component.TertiaryButton
 import app.kaito_dogi.mybrary.core.designsystem.component.TextField
 import app.kaito_dogi.mybrary.core.designsystem.ext.plus
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.ui.navigation.route.AuthRoute
+import app.kaito_dogi.mybrary.feature.verifyotp.component.ResendOtpButton
 import app.kaito_dogi.mybrary.feature.verifyotp.component.VerifyOtpTopAppBar
 
 @Composable
@@ -85,12 +85,11 @@ internal fun VerifyOtpScreen(
 
       Gap(height = MybraryTheme.spaces.xxs)
 
-      TertiaryButton(
-        textResId = R.string.verify_otp_text_resend_otp,
+      ResendOtpButton(
         onClick = onResendOtpClick,
         modifier = Modifier
-          .fillMaxWidth()
-          .padding(bottom = MybraryTheme.spaces.sm),
+          .padding(bottom = MybraryTheme.spaces.sm)
+          .fillMaxWidth(),
         isLoading = uiState.isOtpResending,
       )
     }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpScreen.kt
@@ -87,7 +87,11 @@ internal fun VerifyOtpScreen(
 
       Spacer(modifier = Modifier.weight(1f))
 
-      Text(text = stringResource(id = R.string.verify_otp_text_it_may_take_a_few_minutes))
+      Text(
+        text = stringResource(id = R.string.verify_otp_text_it_may_take_a_few_minutes),
+        color = MybraryTheme.colorScheme.outline,
+        style = MybraryTheme.typography.labelLarge,
+      )
 
       Gap(height = MybraryTheme.spaces.xxs)
 

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
@@ -55,12 +55,11 @@ internal class VerifyOtpViewModel @Inject constructor(
     }
   }
 
-  // FIXME: auth.sendOtp ではなく auth.resendOtp にする
   fun onResendOtpClick() {
     viewModelScope.launchSafe {
       _uiState.update { it.copy(isOtpResending = true) }
 
-      authRepository.otpSignUp(
+      authRepository.resendOtp(
         email = uiState.value.email,
         captchaToken = uiState.value.captchaToken,
       )

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/VerifyOtpViewModel.kt
@@ -39,7 +39,6 @@ internal class VerifyOtpViewModel @Inject constructor(
     _uiState.update { it.copy(otp = otp) }
   }
 
-  // FIXME: HCaptchaToken を受け取る
   fun onVerifyOtpClick() {
     viewModelScope.launchSafe {
       _uiState.update { it.copy(isOtpVerifying = true) }
@@ -56,7 +55,6 @@ internal class VerifyOtpViewModel @Inject constructor(
     }
   }
 
-  // FIXME: HCaptchaToken を受け取る
   // FIXME: auth.sendOtp ではなく auth.resendOtp にする
   fun onResendOtpClick() {
     viewModelScope.launchSafe {

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/component/ResendOtpButton.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/component/ResendOtpButton.kt
@@ -6,8 +6,10 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.designsystem.R
 import app.kaito_dogi.mybrary.core.designsystem.component.TertiaryButton
+import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import kotlinx.coroutines.delay
 
 private const val INITIAL_COUNTDOWN_SECOND = 60
@@ -43,4 +45,15 @@ fun ResendOtpButton(
     isLoading = isLoading,
     isEnabled = countdownSecond == 0,
   )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ResendOtpButtonPreview() {
+  MybraryTheme {
+    ResendOtpButton(
+      onClick = {},
+      isLoading = false,
+    )
+  }
 }

--- a/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/component/ResendOtpButton.kt
+++ b/feature/verify-otp/src/main/java/app/kaito_dogi/mybrary/feature/verifyotp/component/ResendOtpButton.kt
@@ -1,0 +1,46 @@
+package app.kaito_dogi.mybrary.feature.verifyotp.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.kaito_dogi.mybrary.core.designsystem.R
+import app.kaito_dogi.mybrary.core.designsystem.component.TertiaryButton
+import kotlinx.coroutines.delay
+
+private const val INITIAL_COUNTDOWN_SECOND = 60
+
+@Composable
+fun ResendOtpButton(
+  onClick: () -> Unit,
+  isLoading: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  val (countdownSecond, setCountdownSecond) = remember {
+    mutableIntStateOf(INITIAL_COUNTDOWN_SECOND)
+  }
+
+  LaunchedEffect(countdownSecond) {
+    if (countdownSecond > 0) {
+      delay(1_000L)
+      setCountdownSecond(countdownSecond - 1)
+    }
+  }
+
+  TertiaryButton(
+    text = if (countdownSecond > 0) {
+      stringResource(
+        id = R.string.verify_otp_text_resend_otp_in_seconds,
+        countdownSecond,
+      )
+    } else {
+      stringResource(id = R.string.verify_otp_text_resend_otp)
+    },
+    onClick = onClick,
+    modifier = modifier,
+    isLoading = isLoading,
+    isEnabled = countdownSecond == 0,
+  )
+}


### PR DESCRIPTION
## 背景

## 対応したこと

- ワンタイムパスワードの再送処理を実装
- ワンタイムパスワードの再送を60秒経過するまでできないようにした

## 対応していないこと

## UI 差分

|            60秒経過前            |            60秒経過後             |
|:----------------------------:|:----------------------------:|
| <img src="https://github.com/user-attachments/assets/34201dfc-2653-4703-834d-14f563d3d84b" width="300px" /> | <img src="https://github.com/user-attachments/assets/d4f1bf31-df45-4bf7-a584-6afa4db78f5a" width="300px" /> |

## 動作確認手順

- [ ] `記入する`

## 関連リンク
