### PR TITLE
fix: Android 16 対応とビルド互換性を改善

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android-gradle-plugin = "9.1.1"
-android-material = "1.12.0"
+android-material = "1.14.0"
 androidx-browser = "1.8.0"
 androidx-compose-bom = "2026.06.01"
 androidx-compose-material3 = "1.5.0-alpha23"
@@ -28,9 +28,9 @@ retrofit = "2.11.0"
 compileSdk = "37"
 jvmTarget = "17"
 minSdk = "26"
-targetSdk = "35"
-versionCode = "10"
-versionName = "1.0.7"
+targetSdk = "36"
+versionCode = "11"
+versionName = "1.0.8"
 
 [libraries]
 android-material = { module = "com.google.android.material:material", version.ref = "android-material" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 
 // JVM Toolchain（JDK 17）を自動でダウンロードできるようにする
 plugins {
-  id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
## 概要

- targetSdk を Android 16（API 36）へ更新
- versionCode / versionName を 11 / 1.0.8 へ更新
- Foojay toolchain resolver を Gradle 9 対応の 1.0.0 へ更新
- Material Components を 1.14.0 へ更新

## 背景

Google Play の target API レベル要件に対応します。

あわせて、Gradle 9 で削除された `JvmVendorSpec.IBM_SEMERU` を参照する旧 Foojay resolver による Mac mini 上のビルドエラーと、Material Components 1.12.0 が Android 15 で非推奨になった `Window.setStatusBarColor` / `setNavigationBarColor` を無条件で呼び出す問題を解消します。

## 影響

- minSdk は 26 のままです
- Android 15 以降では Material Components から非推奨の system bar color API が呼ばれません
- 次回リリースのアプリバージョンは 1.0.8（versionCode 11）になります

## 確認

- `./gradlew test lint --no-daemon --stacktrace`
- `./gradlew bundleProdRelease --no-daemon --stacktrace`
- release manifest が targetSdk 36、versionCode 11、versionName 1.0.8 であること
- release DEX で Material Components の system bar color API 呼び出しが API 35 未満に限定されていること
