### PR TITLE
fix: 最下部で FAB を非表示にする

### DIFF
--- a/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/ext/ScrollableStateExt.kt
+++ b/core/design-system/src/main/java/app/kaito_dogi/mybrary/core/designsystem/ext/ScrollableStateExt.kt
@@ -1,0 +1,16 @@
+package app.kaito_dogi.mybrary.core.designsystem.ext
+
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+
+val ScrollableState.isScrolledToBottom: Boolean
+  @Composable
+  get() {
+    val isScrolledToBottom by remember(key1 = this) {
+      derivedStateOf { canScrollBackward && !canScrollForward }
+    }
+    return isScrolledToBottom
+  }

--- a/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybookdetail/MyBookDetailScreen.kt
+++ b/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybookdetail/MyBookDetailScreen.kt
@@ -1,5 +1,10 @@
 package app.kaito_dogi.mybrary.feature.mybook.destination.mybookdetail
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -7,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -17,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import app.kaito_dogi.mybrary.core.common.model.Url
 import app.kaito_dogi.mybrary.core.designsystem.R
 import app.kaito_dogi.mybrary.core.designsystem.component.NavigationBarContentScaffold
+import app.kaito_dogi.mybrary.core.designsystem.ext.isScrolledToBottom
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.domain.model.Genre
 import app.kaito_dogi.mybrary.core.domain.model.Memo
@@ -43,21 +50,31 @@ internal fun MyBookDetailScreen(
   onContentChange: (String) -> Unit,
   onSaveClick: () -> Unit,
 ) {
+  val lazyListState = rememberLazyListState()
+  val isScrolledToBottom = lazyListState.isScrolledToBottom
+
   NavigationBarContentScaffold(
     snackbarHost = snackbarHost,
     floatingActionButton = {
-      FloatingActionButton(
-        onClick = onAdditionClick,
+      AnimatedVisibility(
+        visible = !isScrolledToBottom,
+        enter = scaleIn() + fadeIn(),
+        exit = scaleOut() + fadeOut(),
       ) {
-        Icon(
-          painter = painterResource(id = R.drawable.icon_add),
-          contentDescription = stringResource(id = R.string.my_book_detail_alt_create_a_memo),
-        )
+        FloatingActionButton(
+          onClick = onAdditionClick,
+        ) {
+          Icon(
+            painter = painterResource(id = R.drawable.icon_add),
+            contentDescription = stringResource(id = R.string.my_book_detail_alt_create_a_memo),
+          )
+        }
       }
     },
   ) { innerPadding ->
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
+      state = lazyListState,
       // ヘッダーを edge to edge で表示したいため、top は innerPadding の値を使用しない
       contentPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding() + MybraryTheme.spaces.md),
       verticalArrangement = Arrangement.spacedBy(space = MybraryTheme.spaces.md),

--- a/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/MyBookListScreen.kt
+++ b/feature/my-book/src/main/java/app/kaito_dogi/mybrary/feature/mybook/destination/mybooklist/MyBookListScreen.kt
@@ -1,5 +1,10 @@
 package app.kaito_dogi.mybrary.feature.mybook.destination.mybooklist
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,6 +16,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -29,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import app.kaito_dogi.mybrary.core.designsystem.R
 import app.kaito_dogi.mybrary.core.designsystem.component.NavigationBarContentScaffold
 import app.kaito_dogi.mybrary.core.designsystem.ext.plus
+import app.kaito_dogi.mybrary.core.designsystem.ext.isScrolledToBottom
 import app.kaito_dogi.mybrary.core.designsystem.theme.MybraryTheme
 import app.kaito_dogi.mybrary.core.domain.model.MyBook
 import app.kaito_dogi.mybrary.feature.mybook.destination.mybooklist.component.MyBookCell
@@ -45,6 +52,9 @@ internal fun MyBookListScreen(
   onAdditionClick: () -> Unit,
   onMyBookClick: (MyBook) -> Unit,
 ) {
+  val lazyGridState = rememberLazyGridState()
+  val isScrolledToBottom = lazyGridState.isScrolledToBottom
+
   NavigationBarContentScaffold(
     topBar = {
       TopAppBar(
@@ -69,19 +79,27 @@ internal fun MyBookListScreen(
       )
     },
     floatingActionButton = {
-      FloatingActionButton(
-        onClick = onAdditionClick,
+      // 最後の本が FAB と重ならないよう、最下部までスクロールされたら FAB を非表示にする
+      AnimatedVisibility(
+        visible = !isScrolledToBottom,
+        enter = scaleIn() + fadeIn(),
+        exit = scaleOut() + fadeOut(),
       ) {
-        Icon(
-          painter = painterResource(id = R.drawable.icon_add),
-          contentDescription = stringResource(id = R.string.my_book_list_alt_search_for_books),
-        )
+        FloatingActionButton(
+          onClick = onAdditionClick,
+        ) {
+          Icon(
+            painter = painterResource(id = R.drawable.icon_add),
+            contentDescription = stringResource(id = R.string.my_book_list_alt_search_for_books),
+          )
+        }
       }
     },
   ) { innerPadding ->
     LazyVerticalGrid(
       columns = GridCells.Fixed(count = uiState.numberOfColumns),
       modifier = Modifier.fillMaxSize(),
+      state = lazyGridState,
       contentPadding = innerPadding.plus(
         start = MybraryTheme.spaces.md,
         end = MybraryTheme.spaces.md,
@@ -117,7 +135,7 @@ internal fun MyBookListScreen(
             span = { GridItemSpan(currentLineSpan = uiState.numberOfColumns) },
             key = "Spacer:favorite",
           ) {
-            Spacer(modifier = Modifier.height(MybraryTheme.spaces.sm))
+            Spacer(modifier = Modifier.height(height = MybraryTheme.spaces.sm))
           }
         }
       }


### PR DESCRIPTION
## Summary

- Track lazy list and grid scroll position.
- Hide the add FAB when the user reaches the bottom.
- Add a reusable scroll-state extension for Compose.

## Why

The add action should not cover the last book or memo in a list.

## Checks

The FAB branch passes the app DevDebug assemble.